### PR TITLE
Small tweaks to package metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ version must be updated according to the following rules:
 If you want to contribute with one of the Qiskit elements, refer to their individual sites:
 
 * [Terra on GitHub](https://github.com/Qiskit/qiskit-terra)
+* [Aer on GitHub](https://github.com/Qiskit/qiskit-aer)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="Software for developing quantum computing programs",
     long_description="""Qiskit is a software development kit for writing
         quantum computing experiments, programs, and applications. Works with
-        Python 3.5 and 3.6""",
+        Python 3.5, 3.6, and 3.7""",
     url="https://github.com/Qiskit/qiskit",
     author="Qiskit Development Team",
     author_email="qiskit@us.ibm.com",
@@ -33,6 +33,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum",


### PR DESCRIPTION
This commit makes some small tweaks to the README and the package
metadata. First in the package metadata we don't mention python 3.7
as a supported version despite being tested. The other tweak is in the
readme where it adds the link to the Aer repo.