### PR TITLE
Add pro forma tests

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+test_path=./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+cache: pip
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - os: linux
+      dist: xenial
+      python: 3.7
+      env: TOXENV=py37
+      sudo: true
+    - python: "3.5"
+      env: TOXENV=pep8
+language: python
+install: pip install -U tox
+script:
+  - tox
+
+notifications:
+  email: false

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from unittest.util import safe_repr
+
+import fixtures
+import testtools
+
+
+class TestCase(testtools.TestCase):
+
+    def setUp(self):
+        super(TestCase, self).setUp()
+        stdout = self.useFixture(fixtures.StringStream('stdout')).stream
+        self.useFixture(fixtures.MonkeyPatch('sys.stdout', stdout))
+        stderr = self.useFixture(fixtures.StringStream('stderr')).stream
+        self.useFixture(fixtures.MonkeyPatch('sys.stderr', stderr))
+        self.useFixture(fixtures.LoggerFixture(nuke_handlers=False,
+                                               level=None))
+
+    def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
+                              places=None, default_value=0):
+        """Assert two dictionaries with numeric values are almost equal
+
+        Fail if the two dictionaries are unequal as determined by
+        comparing that the difference between values with the same key are
+        not greater than delta (default 1e-8), or that difference rounded
+        to the given number of decimal places is not zero. If a key in one
+        dictionary is not in the other the default_value keyword argument
+        will be used for the missing value (default 0). If the two objects
+        compare equal then they will automatically compare almost equal.
+
+        Args:
+            dict1 (dict): a dictionary.
+            dict2 (dict): a dictionary.
+            delta (number): threshold for comparison (defaults to 1e-8).
+            msg (str): return a custom message on failure.
+            places (int): number of decimal places for comparison.
+            default_value (number): default value for missing keys.
+
+        Raises:
+            TypeError: raises TestCase failureException if the test fails.
+        """
+        if dict1 == dict2:
+            # Shortcut
+            return
+        if delta is not None and places is not None:
+            raise TypeError("specify delta or places not both")
+
+        if places is not None:
+            success = True
+            standard_msg = ''
+            # check value for keys in target
+            keys1 = set(dict1.keys())
+            for key in keys1:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if round(abs(val1 - val2), places) != 0:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            # check values for keys in counts, not in target
+            keys2 = set(dict2.keys()) - keys1
+            for key in keys2:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if round(abs(val1 - val2), places) != 0:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            if success is True:
+                return
+            standard_msg = standard_msg[:-2] + ' within %s places' % places
+
+        else:
+            if delta is None:
+                delta = 1e-8  # default delta value
+            success = True
+            standard_msg = ''
+            # check value for keys in target
+            keys1 = set(dict1.keys())
+            for key in keys1:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if abs(val1 - val2) > delta:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            # check values for keys in counts, not in target
+            keys2 = set(dict2.keys()) - keys1
+            for key in keys2:
+                val1 = dict1.get(key, default_value)
+                val2 = dict2.get(key, default_value)
+                if abs(val1 - val2) > delta:
+                    success = False
+                    standard_msg += '(%s: %s != %s), ' % (safe_repr(key),
+                                                          safe_repr(val1),
+                                                          safe_repr(val2))
+            if success is True:
+                return
+            standard_msg = standard_msg[:-2] + ' within %s delta' % delta
+
+        msg = self._formatMessage(msg, standard_msg)
+        raise self.failureException(msg)

--- a/tests/test_metapackage.py
+++ b/tests/test_metapackage.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+import qiskit
+
+from .base import TestCase
+
+
+class TestMetaPackage(TestCase):
+
+    def test_Aer_import_works(self):
+        self.assertIsNotNone(qiskit.Aer)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+import qiskit
+
+from .base import TestCase
+
+
+class TestAerSimulation(TestCase):
+
+    def test_qasm(self):
+        qr = qiskit.QuantumRegister(1)
+        cr = qiskit.ClassicalRegister(1)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.measure(qr, cr)
+
+        backend = qiskit.Aer.get_backend('qasm_simulator')
+        shots = 2000
+        results = qiskit.execute(circuit, backend, shots=shots).result()
+        self.assertDictAlmostEqual({'0': 1000, '1': 1000},
+                                   results.get_counts(),
+                                   delta=100)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+minversion = 2.1
+envlist = py35, py36, py37, pep8
+skipsdist = True
+
+[testenv]
+usedevelop = true
+install_command = pip install -U {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  LANGUAGE=en_US
+  LC_ALL=en_US.utf-8
+deps = stestr
+commands =
+  stestr run {posargs}
+
+[testenv:pep8]
+deps = flake8
+commands =
+  flake8 tests


### PR DESCRIPTION
This commit adds some very basic test coverage to just verify that the
metapackage works as expected and that when we install the metapackage
the end user experience is consistent and works. It doesn't actually
test anything of substence, just that we can use the Aer simulators
and that the namespacing works correctly. This is good just so we don't
accidently make a mistake and end up breaking something moving forward.