### PR TITLE
 Added GCC OpenMP 4.0 (GOMP 4.0) dependency for Aer. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 cache: pip
 sudo: false
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
This does not seem to be a problem for modern building environments but a recommendation for Qiskit Aer is to check its dependencies before trying to load its components, providing the user with information about the several problems that could arise.