### PR TITLE
Add "autodoc" target for Sphinx autogeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ test/python/test_qasm_python_simulator.pdf
 
 doc/_build/*
 
-doc/**/_autodoc
+doc/**/autodoc
 
 qiskit/terra/bin/*
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ endif
 
 doc: autodoc
 	make -C doc html
+	rm -rf doc/_build/html/_static/font
+	find doc/_build/html/_static/material-design-lite-1.3.0 -type f ! \
+		\( -name 'material.blue-indigo.min.css' -o -name 'LICENSE' \) -delete
 
 clean:
 	make -C doc clean

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,19 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-.PHONY: doc clean
+.PHONY: doc autodoc clean
 
-doc:
+SITE_PACKAGES := $(shell pip show qiskit | grep Location | sed 's/Location: //')
+
+autodoc:
+ifneq ($(SITE_PACKAGES), )
+	sphinx-apidoc --output doc/autodoc --separate --implicit-namespaces --module-first -d 16 \
+		$(SITE_PACKAGES)/qiskit
+endif
+
+doc: autodoc
 	make -C doc html
 
 clean:
 	make -C doc clean
+	rm -rf doc/autodoc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ release = '0.7'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -75,6 +76,16 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+# A boolean that decides whether module names are prepended to all object names
+# (for object types where a “module” of some kind is defined), e.g. for
+# py:function directives.
+add_module_names = False
+
+# A list of prefixes that are ignored for sorting the Python module index
+# (e.g., if this is set to ['foo.'], then foo.bar is shown under B, not F).
+# This can be handy if you document a project that consists of a single
+# package. Works only for the HTML builder currently.
+modindex_common_prefix = ['qiskit.']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,8 +7,7 @@ Welcome to Qiskit's documentation!
 
    overview
    install
-
-
+   Qiskit Module reference <autodoc/qiskit>
 
 Indices and tables
 ==================


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add a `make autodoc` target for generating the documentation for the
`qiskit` modules. 

At the moment it assumes the packages are installed via pip and available in the PYTHONPATH, aiming at the autogeneration from stable versions in the CI - if not, the generation of the documentation proceeds without the automatically generated content. 

### Details and comments

Next steps would be including `aqua` autogenerated documentation (currently it only looks for the `qiskit/*` modules), and on lower priority add some convenience for user to generate it without installing the modules (at the moment it can be done by manually invoking `make doc` with the right PYTHONPATH and some degree of manual effort).
