### PR TITLE
Include terra docs in main toc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,8 +7,8 @@ Welcome to Qiskit's documentation!
 
    overview
    install
-   roadmap
    Qiskit Terra <terra/index>
+   roadmap
    Qiskit Module reference <autodoc/qiskit>
 
 Indices and tables

--- a/docs/terra/index.rst
+++ b/docs/terra/index.rst
@@ -1,10 +1,6 @@
 Qiskit Terra Documentation
 ##########################
 
-
-Table of Contents
-*****************
-
 .. toctree::
    :maxdepth: 2
 
@@ -23,5 +19,5 @@ Table of Contents
 Authors
 *******
 
-Qiskit Terra would not be possible without the `many contributors <https://github.com/Qiskit/qiskit-terra/graphs/contributors>`_ 
+Qiskit Terra would not be possible without the `many contributors <https://github.com/Qiskit/qiskit-terra/graphs/contributors>`_
 from our community.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Tweak for including the terra docs "better" into the main TOC, as in:

```
Overview
Qiskit Installation ans setup
...
Qiskit Terra
  Overview
  Getting started
  ...
Roadmap
```

Please note there might still be some oddities visually in the theme, in the left TOC section, that can be a bit misleading. If in doubt when working with the TOC, the main pane at `docs/_build/html/terra/index.html` is at the moment more reliable when it comes to nesting.

### Details and comments


