### PR TITLE
Overrides the command `bdist_wheel` to fail.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def _reinstall_terra():
 
 class _install(install):
     """Custom install command to force reinstalling qiskit-terra after removing
-    qiskit"""
+    qiskit."""
 
     def run(self):
         super().run()
@@ -36,16 +36,37 @@ class _install(install):
 
 class _develop(develop):
     """Custom develop command to force reinstalling qiskit-terra after removing
-    qiskit"""
+    qiskit."""
 
     def run(self):
         super().run()
         _reinstall_terra()
 
 
+_COMMANDS = { 'develop': _develop, 'install': _install }
+
+
+try:
+    from wheel.bdist_wheel import bdist_wheel
+
+    class _bdist_wheel(bdist_wheel):
+        """Custom bdist_wheel command to force cancelling qiskit-terra wheel
+        creation."""
+
+        def run(self):
+            """Do nothing so the command intentionally fails."""
+            pass
+
+
+    _COMMANDS['bdist_wheel'] = _bdist_wheel
+
+except:
+    pass
+
+
 setup(
     name="qiskit",
-    version="0.7.1",
+    version="0.7.2",
     description="Software for developing quantum computing programs",
     long_description="""Qiskit is a software development kit for writing
         quantum computing experiments, programs, and applications. Works with
@@ -76,6 +97,7 @@ setup(
     # before installing qiskit 0.7 but after installing its dependencies. More
     # detailed info is provided at:
     # https://github.com/Qiskit/qiskit/issues/27#issue-396844438
+    # https://github.com/Qiskit/qiskit/issues/27#issuecomment-455598103
     #
     # The fix overrides 'install' and 'develop' setuptools commands to force
     # reinstalling 'qiskit-terra' after installation to restore the missing files.
@@ -83,5 +105,5 @@ setup(
     # For this fix to work, we cannot distribute a wheel version of the metapackage
     # (which does not provide any advantage right now). We can remove the fix once
     # we don't support updating from 0.6.
-    cmdclass={ 'install': _install, 'develop': _develop }
+    cmdclass=_COMMANDS
 )


### PR DESCRIPTION
Fix #27 

Just after downloading a package, if the `wheel` package is present,
`pip` creates a wheel distribution of the package. `pip` then uses
it to install the package. When a wheel distribution is used, `pip` does
not run `setup.py` preventing the reinstallation of `qiskit-terra`.

To avoid the creation of the wheel, the custom method overriding
`bdist_wheel` does nothing during the `run` method. Failing to build the
metapackage `qiskit` is intended. Since the wheel is not present, `pip`
will use the regular package and run `setup.py` as usual.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

