### PR TITLE
Fix typos in qiskit-terra docs

### DIFF
--- a/docs/terra/backend_monitoring_tools.rst
+++ b/docs/terra/backend_monitoring_tools.rst
@@ -34,7 +34,7 @@ to process, e.g. jobs with many circuits and/or shots, or may have to
 wait in queue for other users. In situations such as these, it is
 beneficial to have a way of monitoring the progress of a job, or several
 jobs at once. As of Qiskit ``0.6+`` it is possible to monitor the status
-of a job in a Jupyter notebook, and also in a Python script (verision
+of a job in a Jupyter notebook, and also in a Python script (version
 ``0.7+``).
 
 Lets see how to make use of these tools.
@@ -50,7 +50,7 @@ monitor its status.
     q = QuantumRegister(2)
     c = ClassicalRegister(2)
     qc = QuantumCircuit(q, c)
-    
+
     qc.h(q[0])
     qc.cx(q[0], q[1])
     qc.measure(q, c);
@@ -73,7 +73,7 @@ Lets grab the least busy backend
 
 
 Monitor the job using ``job_monitor`` in blocking-mode (i.e. using the
-same thread as the Python interpretor)
+same thread as the Python interpreter)
 
 .. code:: python
 
@@ -152,7 +152,7 @@ information for a single backend by calling ``backend_monitor``:
         n_registers: 1
         backend_name: ibmq_16_melbourne
         allow_q_object: True
-    
+
     Qubits [Name / Freq / T1 / T2 / U1 err / U2 err / U3 err / Readout err]
     -----------------------------------------------------------------------
         Q0 / 5.10005 GHz / 67.38168 µs / 20.8927 µs / 0.0 / 0.00157 / 0.00313 / 0.0447
@@ -169,7 +169,7 @@ information for a single backend by calling ``backend_monitor``:
         Q11 / 5.00527 GHz / 61.25009 µs / 101.05622 µs / 0.0 / 0.00181 / 0.00362 / 0.0816
         Q12 / 4.76015 GHz / 96.01526 µs / 143.34551 µs / 0.0 / 0.00332 / 0.00663 / 0.1608
         Q13 / 4.96847 GHz / 22.97295 µs / 39.88249 µs / 0.0 / 0.00524 / 0.01047 / 0.0493
-    
+
     Multi-Qubit Gates [Name / Type / Gate Error]
     --------------------------------------------
         CX1_0 / cx / 0.04706
@@ -210,9 +210,9 @@ available to us, then we can use ``backend_overview()``
     Operational:  True          Operational:  True
     Avg. T1:      55.1          Avg. T1:      50.9
     Avg. T2:      69.6          Avg. T2:      25.3
-    
-    
-    
+
+
+
 
 
 There are also Jupyter magic equivalents that give more detailed

--- a/docs/terra/overview.rst
+++ b/docs/terra/overview.rst
@@ -1,11 +1,11 @@
 Overview
 ========
 
-Terra, the ‘earth’ element, is the foundation on which the rest of Qiskit lies. 
-Terra provides a bedrock for composing quantum programs at the level of circuits and pulses, 
-to optimize them for the constraints of a particular device, and to manage the execution 
-of batches of experiments on remote-access devices. Terra defines the interfaces 
-for a desirable end-user experience, as well as the efficient handling of layers 
+Terra, the ‘earth’ element, is the foundation on which the rest of Qiskit lies.
+Terra provides a bedrock for composing quantum programs at the level of circuits and pulses,
+to optimize them for the constraints of a particular device, and to manage the execution
+of batches of experiments on remote-access devices. Terra defines the interfaces
+for a desirable end-user experience, as well as the efficient handling of layers
 of optimization, pulse scheduling and backend communication.
 
 
@@ -19,24 +19,24 @@ located in *test*. The *qiskit* directory is the main module of Terra. This moud
 Quantum Circuits
 ^^^^^^^^^^^^^^^^
 
-A quantum circuit is a model for quantum computing in which a computation is done by performing a 
-sequence of quantum operations (usually gates) on a register of qubits. A quantum circuit usually 
-starts with the qubits in the :math:`|0,…,0>` state (Terra assumes this unless otherwise specified) and 
-these gates evolve the qubits to states that cannot be efficiently represented on a classical computer. 
+A quantum circuit is a model for quantum computing in which a computation is done by performing a
+sequence of quantum operations (usually gates) on a register of qubits. A quantum circuit usually
+starts with the qubits in the :math:`|0,…,0>` state (Terra assumes this unless otherwise specified) and
+these gates evolve the qubits to states that cannot be efficiently represented on a classical computer.
 To extract information on the state a quantum circuit must have a measurement which maps the outcomes
-(possible random due to the fundamental nature of quantum systems) to classical registers which 
+(possible random due to the fundamental nature of quantum systems) to classical registers which
 can be efficiently represented.
 
 
 Transpiler
 ^^^^^^^^^^
 
-A major part of research on quantum computing is working out how to run a quantum 
+A major part of research on quantum computing is working out how to run a quantum
 circuits on real devices.  In these devices, experimental errors and decoherence introduce
-errors during computation. Thus, to obtain a robust implementation it is essential 
-to reduce the number of gates and the overall running time of the quantum circuit. 
+errors during computation. Thus, to obtain a robust implementation it is essential
+to reduce the number of gates and the overall running time of the quantum circuit.
 The transpiler introduces the concept of a pass manager to allow users to explore
-optimization and find better quantum circuits for their given algorithm. We call it a 
+optimization and find better quantum circuits for their given algorithm. We call it a
 transpiler as the end result is still a circuit.
 
 
@@ -44,38 +44,38 @@ Tools
 ^^^^^
 
 This directory contains tools that make working with Terra simpler. It contains functions that
-allow the user to execute quantum circuits and not worry about the optimization for a given 
+allow the user to execute quantum circuits and not worry about the optimization for a given
 backend. It also contains a compiler which uses the transpiler to map an array of quantum circuits
-to a `qobj` (quantum object) which can then be run on a backend. The `qobj` is a convenient 
-representation (currently JSON) of the data that can be easily sent to the remote backends. 
-It also has functions for monitoring jobs, backends, and parallelization of transpilation tasks. 
+to a `qobj` (quantum object) which can then be run on a backend. The `qobj` is a convenient
+representation (currently JSON) of the data that can be easily sent to the remote backends.
+It also has functions for monitoring jobs, backends, and parallelization of transpilation tasks.
 
 
 Backends and Results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once the user has made the `qobj` to run on the backend they need to have a convenient way of 
-working with it. In Terra we do this using three parts: the *provider*, the *backend*, 
-and the *job*. 
+Once the user has made the `qobj` to run on the backend they need to have a convenient way of
+working with it. In Terra we do this using three parts: the *provider*, the *backend*,
+and the *job*.
 
-A *Provider* is an entity that provides access to a group of different backends (for example, 
-backends available through the `IBM Q <https://www.research.ibm.com/ibm-q/technology/devices/>`_). 
-It interacts with those backends to, for example, 
+A *Provider* is an entity that provides access to a group of different backends (for example,
+backends available through the `IBM Q <https://www.research.ibm.com/ibm-q/technology/devices/>`_).
+It interacts with those backends to, for example,
 find out which ones are available, or retrieve an instance of a particular backend.
 
-*Backends* represent either a simulator or a real quantum computer and are responsible 
+*Backends* represent either a simulator or a real quantum computer and are responsible
 for running quantum circuits and returning results. They have a run method which takes in a
 `qobj` as input and returns a `BaseJob` object. This object allows asynchronous running of
 jobs for retrieving results from a backend when the job is completed.
 
-*Job* instances can be thought of as the “ticket” for a submitted job. 
-They find out the execution’s state at a given point in time (for example, 
+*Job* instances can be thought of as the “ticket” for a submitted job.
+They find out the execution’s state at a given point in time (for example,
 if the job is queued, running, or has failed) and also allow control over the job.
 
-Once the job has finished Terra allows the results to be obtained from the remote backends 
-using `result = job.result()`.  This result object holds the quantum data and the most 
-common way of interacting with it is by using `result.get_counts(circuit)`. This method allows 
-the user to get the raw counts from the quantum circuit and use them for more analysis with 
+Once the job has finished Terra allows the results to be obtained from the remote backends
+using `result = job.result()`.  This result object holds the quantum data and the most
+common way of interacting with it is by using `result.get_counts(circuit)`. This method allows
+the user to get the raw counts from the quantum circuit and use them for more analysis with
 quantum inofrmation tools provided by Terra.
 
 
@@ -83,18 +83,18 @@ quantum inofrmation tools provided by Terra.
 Quantum Information
 ^^^^^^^^^^^^^^^^^^^
 
-To perform more advance algorithms and analyzation of the circuits run on the quantum computer it is
+To perform more advance algorithms and analysis of the circuits run on the quantum computer it is
 important to have tools to perform simple quantum information tasks. These include methods to estimate
-metrics on and generate quantum states, operations, and channels. 
+metrics on and generate quantum states, operations, and channels.
 
 
 Visualization Tools
 ^^^^^^^^^^^^^^^^^^^
 
-In Terra we have many tools to visualize a quantum circuit. This allows a quick inspection of the quantum 
-circuit to make sure it is what the user wanted to implement. There is a text, python and latex version. 
-Once the circuit has run it is important to be able to view the output. There is a simple function 
-(`plot_histogram`) to plot the results from a quantum circuit including an interactive version. 
-There is also a function `plot_state` and ` plot_bloch_vector` that allow the plotting of a 
-quantum state. These functions are usually only used when using the `statevector_simulator` 
-backend but can also be used on real data after running state tomography experiments (ignis). 
+In Terra we have many tools to visualize a quantum circuit. This allows a quick inspection of the quantum
+circuit to make sure it is what the user wanted to implement. There is a text, python and latex version.
+Once the circuit has run it is important to be able to view the output. There is a simple function
+(`plot_histogram`) to plot the results from a quantum circuit including an interactive version.
+There is also a function `plot_state` and ` plot_bloch_vector` that allow the plotting of a
+quantum state. These functions are usually only used when using the `statevector_simulator`
+backend but can also be used on real data after running state tomography experiments (ignis).

--- a/docs/terra/release_history.rst
+++ b/docs/terra/release_history.rst
@@ -20,7 +20,7 @@ deprecation periods warning of any coming changes.
 There is also the introduction of the following new features:
 
 * A new ASCII art circuit drawing output mode
-* A new ciruit drawing interface off of QuantumCircuit objects. Now you can
+* A new circuit drawing interface off of QuantumCircuit objects. Now you can
   call ``circuit.draw()`` or ``print(circuit)`` and render a drawing of
   the circuit.
 * A visualizer for drawing the DAG representation of a circuit

--- a/docs/terra/terra_parallel_tools.rst
+++ b/docs/terra/terra_parallel_tools.rst
@@ -45,11 +45,11 @@ circuit as inputs.
     def build_qv_circuit(idx, seeds, width, depth):
         """Builds a single Quantum Volume circuit.  Two circuits,
         one with measurements, and one widthout, are returned.
-    
+
         The model circuits consist of layers of Haar random
         elements of SU(4) applied between corresponding pairs
         of qubits in a random bipartition.
-        
+
         See: https://arxiv.org/abs/1811.12926
         """
         np.random.seed(seeds[idx])
@@ -89,7 +89,7 @@ circuit as inputs.
 Generate 1000 circuits in parallel and track progress
 -----------------------------------------------------
 
-Becuase Quantum Volume circuits are generated randomly for the NumPy
+Because Quantum Volume circuits are generated randomly for the NumPy
 random number generator, we must be careful when running in parallel. If
 the random number generator is not explicitly seeded, the computer uses
 the current time as a seed value. When running in parallel, this can


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix a couple of typo in qiskit-terra documentation. In some files trailing white spaces have been stripped.

