### PR TITLE
Add DOI to generate_bibtex script

### DIFF
--- a/tools/generate_bibtex.py
+++ b/tools/generate_bibtex.py
@@ -8,4 +8,5 @@ with open('../Qiskit.bib', 'w') as fd:
     fd.write("@misc{ Qiskit,\n")
     fd.write('       author = {%s},\n' % ' and '.join(authors))
     fd.write('       title = {Qiskit: An Open-source Framework for Quantum Computing},\n')
-    fd.write('       year = {2019},\n}')
+    fd.write('       year = {2019},\n')
+    fd.write('       doi = {10.5281/zenodo.2562110}\n}')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A DOI was manually added to the bibtex file in #74, however that file is
generated by a script. When we update the AUTHORS file the
generate_bibtex.py script is used to create a new up to date bibtex
file. To ensure we don't lose the DOI line from future updates this
commit adds it to the generate script.

### Details and comments