### PR TITLE
Add constraints to pin pylint to known working version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+astroid==2.1.0
+pylint==2.2.2
+cryptography==2.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = true
-install_command = pip install -U {opts} {packages}
+install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a constraints file so we're always running pylint and
astroid at known working version. The 2 are requirements are very coupled
and small changes in one often requires an update in the other.
Unfortunately new versions of pylint often change or add rules which
makes running it unpinned not a good decision. To ensure a consistent
environment for running pylint this commit leverages pip constraints to
make sure we always install the same version of astroid and pylint.

### Details and comments