### PR TITLE
Bump qiskit-terra version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,13 @@ Added
 
 - Added qiskit-ignis to the set of installed packages (#164)
 
+Changed
+-------
+
+- Increased the qiskit-terra version to v0.7.1 which includes a fix for the
+  BasicAer simulator issue documented in Qiskit/qiskit-terra#1583 and
+  Qiskit/qiskit-terra#1838 (#167).
+
 
 `0.7.3`_ - 2019-02-20
 =====================

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.develop import develop
 
-qiskit_terra = "qiskit_terra==0.7.0"
+qiskit_terra = "qiskit_terra==0.7.1"
 
 requirements = [
     qiskit_terra,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was a new qiskit-terra bugfix release today to fix an error in the
BasicAer python simulator. Bump the requirement for qiskit-terra to use
this.

### Details and comments