### PR TITLE
Prepare release history and changelog for release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,3 +70,5 @@ Added
 .. _0.7.3: https://github.com/Qiskit/qiskit/compare/0.7.2...0.7.3
 .. _0.7.2: https://github.com/Qiskit/qiskit/compare/0.7.1...0.7.2
 .. _0.7.1: https://github.com/Qiskit/qiskit/compare/0.7.0...0.7.1
+
+.. _Keep a Changelog: http://keepachangelog.com/en/1.0.0/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+
+`0.8.0`_ - 2019-03-05
+=====================
+
 Added
 -----
 
@@ -53,10 +57,16 @@ Fixed
 - Fixed an issue when upgrading from an older ``qiskit`` package to a version
   `>=0.7.0` (#32)
 
-`0.7.0`_ - 2018-12-19
+0.7.0 - 2018-12-19
 =====================
 
 Added
 -----
 
 - First release, includes qiskit-terra and qiskit-aer
+
+.. _UNRELEASED: https://github.com/Qiskit/qiskit-terra/compare/0.8.0...HEAD
+.. _0.8.0: https://github.com/Qiskit/qiskit/compare/0.7.3...0.8.0
+.. _0.7.3: https://github.com/Qiskit/qiskit/compare/0.7.2...0.7.3
+.. _0.7.2: https://github.com/Qiskit/qiskit/compare/0.7.1...0.7.2
+.. _0.7.1: https://github.com/Qiskit/qiskit/compare/0.7.0...0.7.1

--- a/docs/release_history.rst
+++ b/docs/release_history.rst
@@ -1,6 +1,14 @@
 Release history
 ===============
 
+Qiskit 0.8
+----------
+
+In Qiskit 0.8 we introduced the Qiskit Ignis element. It also includes the
+Qiskit Terra element 0.7.1 release which contains a bug fix for the BasicAer
+Python simulator.
+
+
 Qiskit 0.7
 ----------
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the plan to tag and push the qiskit 0.8 release today we need to
prepare the release notes and changelog to be ready for when we tag it.
This commit does that by moving the unreleased changelog to the 0.8.0
tag and adding 0.8 to the release history.

### Details and comments