### PR TITLE
added tabs to header

### DIFF
--- a/docs/theme/_templates/layout.html
+++ b/docs/theme/_templates/layout.html
@@ -26,8 +26,10 @@
         <a href="/terra">Terra</a>
         <a href="/aer">Aer</a>
         <a href="/aqua">Aqua</a>
+        <a href="/ignis">Ignis</a>
       </nav>
       <nav class="second">
+        <a class="external" href="/tutorials">Tutorials</a>
         <a class="external" href="/documentation" selected>Documentation</a>
         <a class="external" href="/vscode">Tools</a>
         <a class="external" href="/fun">Fun</a>

--- a/docs/theme/static/css/theme.css
+++ b/docs/theme/static/css/theme.css
@@ -45,10 +45,10 @@ th.field-name{
 div .simple li dl dt{
   font-weight: normal !important;
 }
-.second a:not(.external){
+.second a:not(.external) {
     color: #d4d4d4;
 }
-.second a:not(.external):hover{
+.second a:not(.external):hover {
     color: #fff;
 }
 td.field-body {
@@ -66,6 +66,9 @@ h1{
   margin-top: 0 !important;
   margin-bottom: 2rem !important;
 }
+
+/* Header Toolbar Styles */
+
 header {
   display: flex;
   background-color: #21252b;
@@ -99,7 +102,7 @@ header {
 }
 .toolbar > a.home {
   font-weight: 500;
-  margin-left: -1em; /* Reduce the 1em padding from the <a> */
+  /*margin-left: -1em; /* Reduce the 1em padding from the <a> */
 }
 .toolbar nav {
   display: flex;
@@ -628,21 +631,18 @@ cursor: pointer;
     .iconMediumResponsiveTableOfContent{
         display: none;
     }
-
-    .second .external {
+    .home {
+       padding-left: 32px !important;
+    }
+    .document .page-content{
+        padding: 40px 14px !important;
+    }
+ }
+ @media (max-width: 895px) {
+     .second .external {
         display: none !important;
     }
     .first{
         display: none !important;
     }
-    .home {
-       padding-left: 32px !important;
-    }
-    .second {
-        padding-right: 16px;
-    }
-    .document .page-content{
-        padding: 40px 14px !important;
-    }
-
  }


### PR DESCRIPTION
### Summary
Added missing tabs on Header

### Details and comments
This is a WIP, because we missed the responsiveness. But it can be merged.

The ideal is to create a reusable webcomponent for the header, including the responsive and off-canvas menu like on Qiskit.org.

This PR closes #176 and [the related one on Qiskit.org repository](https://github.com/Qiskit/qiskit/issues/176)

