### PR TITLE
Added search box and search results page

### DIFF
--- a/docs/theme/_templates/globaltoc.html
+++ b/docs/theme/_templates/globaltoc.html
@@ -1,4 +1,30 @@
 {% block menu %}
+{#
+    basic/searchbox.html
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Sphinx sidebar template: quick search box.
+
+    :copyright: Copyright 2007-2019 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- if builder != "singlehtml" %}
+<div id="searchbox" role="search">
+    <div class="searchformwrapper">
+    <form class="search-form" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" class="search-input" placeholder="Search docs..."/>
+        <button type="submit" class="search-button">
+            <svg height="20" width="20" fill="#6F6F6F" viewBox="0 0 32 32" class="search-button-icon">
+                <title>search</title>
+                <g>
+                    <path d="M30 28.586l-7.552-7.552a11.018 11.018 0 1 0-1.414 1.414L28.586 30zM5 14a9 9 0 1 1 9 9 9.01 9.01 0 0 1-9-9z"></path>
+                </g>
+            </svg>
+        </button>
+    </form>
+    </div>
+</div>
+{%- endif %}
 <div class="globaltoc">
   <span class="mdl-layout-title toc">{{ _('Table Of Contents') }}</span>
   {% set toctree = toctree(maxdepth=4, collapse=False, includehidden=True, titles_only=False) %}

--- a/docs/theme/_templates/search.html
+++ b/docs/theme/_templates/search.html
@@ -1,0 +1,46 @@
+{#
+    basic/search.html
+    ~~~~~~~~~~~~~~~~~
+
+    Template for the search page.
+
+    :copyright: Copyright 2007-2019 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- extends "layout.html" %}
+{% set title = _('Search') %}
+{%- block scripts %}
+    {{ super() }}
+    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+{%- endblock %}
+{% block extrahead %}
+  <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
+  {{ super() }}
+{% endblock %}
+{% block body %}
+  <h1 id="search-documentation">{{ _('Search') }}</h1>
+  <div id="fallback" class="admonition warning">
+  <script type="text/javascript">$('#fallback').hide();</script>
+  <p>
+    {% trans %}Please activate JavaScript to enable the search
+    functionality.{% endtrans %}
+  </p>
+  </div>
+  {% if search_performed %}
+    <h2>{{ _('Search Results') }}</h2>
+    {% if not search_results %}
+      <p>{{ _('Your search did not match any documents. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.') }}</p>
+    {% endif %}
+  {% endif %}
+  <div id="search-results">
+  {% if search_results %}
+    <ul>
+    {% for href, caption, context in search_results %}
+      <li><a href="{{ pathto(item.href) }}">{{ caption }}</a>
+        <div class="context">{{ context|e }}</div>
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  </div>
+{% endblock %}

--- a/docs/theme/static/css/theme.css
+++ b/docs/theme/static/css/theme.css
@@ -444,6 +444,39 @@ cursor: pointer;
 .toctree-l5 {
     padding-left: 18px !important;
 }
+
+/* Search bar Styles */
+.search-form {
+    display: flex;
+    flex-direction: row;
+    padding-left: 2em;
+    padding-right: 3em;
+}
+.search-input {
+    padding: 1.1em;
+    width: 90%;
+    background-color: #f3f3f3;
+    border: 1px solid #BEBEBE;
+    border-right: 0;
+}
+.search-input:focus {
+    border: 1px solid #0062ff;
+    outline: 0;
+}
+.search-button {
+    width: 3rem;
+    padding: 1em;
+    background-color: #F3F3F3;
+    color: #A4A4A4;
+    outline-color: #BEBEBE;
+    border: 1px solid #BEBEBE;
+    border-left: 0;
+}
+.search-button-icon {
+    color: #6F6F6F;
+    border-width: 2px !important;
+}
+
 @media(min-width: 1630px) {
   .mdl-layout--fixed-drawer .mdl-layout__content{
     margin-left: 26rem !important;

--- a/docs/theme/static/css/theme.css
+++ b/docs/theme/static/css/theme.css
@@ -477,6 +477,11 @@ cursor: pointer;
     color: #6F6F6F;
     border-width: 2px !important;
 }
+#searchbox > .highlight-link > a {
+    padding-left: 2.3em;
+    margin-top: -2em;
+    display: block;
+}
 
 @media(min-width: 1630px) {
   .mdl-layout--fixed-drawer .mdl-layout__content{

--- a/docs/theme/static/css/theme.css
+++ b/docs/theme/static/css/theme.css
@@ -451,6 +451,7 @@ cursor: pointer;
     flex-direction: row;
     padding-left: 2em;
     padding-right: 3em;
+    padding-bottom: 2em;
 }
 .search-input {
     padding: 1.1em;


### PR DESCRIPTION
### Summary
Added a search box and the correspondent search results page to the documentation website.
This looks like:

![image](https://user-images.githubusercontent.com/650752/54437972-148b7280-4736-11e9-91d8-f6447698e98f.png)

![image](https://user-images.githubusercontent.com/650752/54438044-34bb3180-4736-11e9-9178-00e667657a34.png)

### Details and comments
This PR closes #180 

