### PR TITLE
Add docs for provider plugins

### DIFF
--- a/docs/terra/providers.rst
+++ b/docs/terra/providers.rst
@@ -1,0 +1,46 @@
+===========================
+Creating External Providers
+===========================
+
+Terra provides a plugin interface to define external backend providers
+
+
+Creating a Plugin
+-----------------
+
+Creating a plugin is fairly straightforward and doesn't require much additional
+effort on top of creating a provider. All external provider classes must be
+defined off the abstract class defined at ``qiskit.backends.baseprovider``.
+
+Entry Point
+-----------
+
+Once you've created your plugin class you need to add a `setuptools`_ entry
+point to your provider to enable Qiskit-Terra to find the plugin. The entry
+point must be added to the ``qiskit.providers`` namespace.
+
+.. _setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
+
+For example, in your provider package's setup.py you would add something like::
+
+   entry_points={'qiskit.providers':
+      ['MyProvider = my_provider.provider:MyProvider']
+   }
+
+where ``my_provider.provider`` is the import path and ``MyProvider`` is the
+provider class. Once this is added to your setup.py then whenever the package is
+installed Qiskit-terra will detect the provider is installed and a
+``MyProvider`` provider instance to the qiskit namespace.
+
+
+Using Provider Plugins
+----------------------
+
+When installing provider plugins the name of the entry point becomes the name
+of providers off the global instance of ``qiskit.providers`` namespace. So
+continuing from the above example after installing the ``my_provider`` package
+you can access the backends provided by ``MyProvider`` by using
+``qiskit.providers.MyProvider``. So if you wanted to list the backends on the
+custom provider you could do that with:
+``qiskit.providers.MyProvider.backends()`` Any other provider plugins that
+are installed will also be accessible off of ``qiskit.providers``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Terra change Qiskit/qiskit-terra#1465 adds a plugin interface to allow
external providers to have a common interface with terra. It also
providers users a consistent place to access external providers. This
commit adds the documentation for this new feature.

### Details and comments
