### PR TITLE
Add source links via sphinx.ext.viewcode

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,8 @@ release = '0.7'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/theme/_templates/globaltoc.html
+++ b/docs/theme/_templates/globaltoc.html
@@ -28,7 +28,8 @@
 <div class="globaltoc">
   <span class="mdl-layout-title toc">{{ _('Table Of Contents') }}</span>
   {% set toctree = toctree(maxdepth=4, collapse=False, includehidden=True, titles_only=False) %}
-  {% if toctree %}
+  {# The toctree is disabled on "source code" pages, for reducing their size. #}
+  {% if toctree and "_modules" not in pagename %}
       {% set lines = toctree.split('\n') %}
       <nav class="mdl-navigation">
           {{ toctree }}

--- a/docs/theme/static/css/theme.css
+++ b/docs/theme/static/css/theme.css
@@ -6,7 +6,7 @@ pre{
    font-family: "IBM Plex Mono", "Menlo", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", Courier, monospace !important;
 }
 
-.page-content .code, .page-content .highlight pre, .page-content code:not(.download){
+.page-content .code, .page-content .highlight pre, .page-content code:not(.download), .page-content .viewcode-block {
     font-family: "IBM Plex Mono", "Menlo", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", Courier, monospace !important;}
 
 .mdl-layout-title{


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #79.

Reintroduces the links to source from module members, using `sphinx.ext.viewcode`. This means a bunch of pages are added to the rendered doc (in the `_modules` directory), one per source file - for reducing the size of those pages, the PR includes removing the TOC from those source files (although still, ~12mb are added): if size is a concern, some alternatives are sketched in #79.



### Details and comments


