### PR TITLE
Add depth tracking to random hex circuit benchmarks

### DIFF
--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -64,6 +64,9 @@ class BenchRandomCircuitHex:
     def time_simulator_transpile(self, _):
         transpiler.transpile(self.circuit, self.sim_backend)
 
+    def track_depth_simulator_transpile(self, _):
+        return transpiler.transpile(self.circuit, self.sim_backend).depth()
+
     def time_ibmq_backend_transpile(self, _):
         # Run with ibmq_16_melbourne configuration
         coupling_map = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
@@ -73,3 +76,13 @@ class BenchRandomCircuitHex:
         transpiler.transpile(self.circuit,
                              basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
                              coupling_map=coupling_map)
+
+    def track_depth_ibmq_backend_transpile(self, _):
+        # Run with ibmq_16_melbourne configuration
+        coupling_map = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
+                        [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],
+                        [11, 3], [11, 10], [11, 12], [12, 2], [13, 1],
+                        [13, 12]]
+        return transpiler.transpile(self.circuit,
+                                    basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
+                                    coupling_map=coupling_map).depth()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds 2 new benchmarks that use the same random hex circuit
setup but instead of measuring the time it takes to transpile() it
tracks the depth of the output circuit. This will serve as an example
for how we can track other transpiler performance metrics over time in
terra (not just depth).

### Details and comments