### PR TITLE
Remove randomness from random_hex_circuit_benchmark

### DIFF
--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -10,8 +10,6 @@
 
 import copy
 
-import numpy as np
-
 try:
     from qiskit.mapper import _compiling as compiling
 except ImportError:
@@ -25,14 +23,13 @@ import qiskit.tools.qi.qi as qi
 # Make a random circuit on a ring
 def make_circuit_ring(nq, depth, seed):
     assert int(nq / 2) == nq / 2  # for now size of ring must be even
-    np.random.seed(seed)
     # Create a Quantum Register
     q = QuantumRegister(nq)
     # Create a Classical Register
     c = ClassicalRegister(nq)
     # Create a Quantum Circuit
     qc = QuantumCircuit(q, c)
-    offset = np.random.randint(2)
+    offset = 1
     # initial round of random single-qubit unitaries
     for i in range(nq):
         qc.h(q[i])
@@ -54,6 +51,8 @@ def make_circuit_ring(nq, depth, seed):
 
 class BenchRandomCircuitHex:
     params = [2 * i for i in range(2, 8)]
+    param_names = ['n_qubits']
+    version = 2
 
     def setup(self, n):
         depth = 2 * n

--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -21,7 +21,7 @@ import qiskit.tools.qi.qi as qi
 
 
 # Make a random circuit on a ring
-def make_circuit_ring(nq, depth, seed):
+def make_circuit_ring(nq, depth):
     assert int(nq / 2) == nq / 2  # for now size of ring must be even
     # Create a Quantum Register
     q = QuantumRegister(nq)
@@ -56,8 +56,7 @@ class BenchRandomCircuitHex:
 
     def setup(self, n):
         depth = 2 * n
-        seed = 5
-        self.circuit = make_circuit_ring(n, depth, seed)[0]
+        self.circuit = make_circuit_ring(n, depth)[0]
         self.sim_backend = BasicAer.get_backend('qasm_simulator')
 
     def time_simulator_transpile(self, _):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The random_hex benchmark had one np.random.randomint() call that was
used to determine if the cnots in the circuit were for odd or even
numbered qubits. While not a big difference (and difficult to detect by
visual inspection) we want to eliminate any difference between runs for
benchmarking. These subtle differences can make the results unusable and
anomaly detection more difficult. To that end this commit just sets the
random value to be fixed so the generated circuit will always be the
same. Since this changes the results the version for the benchmark is
changed so that we'll treat new results different from the previous
results with the random number.

### Details and comments


