### PR TITLE
Fix typo in docs (missing backslash for T-dagger gate)

### DIFF
--- a/docs/terra/summary_of_quantum_operations.rst
+++ b/docs/terra/summary_of_quantum_operations.rst
@@ -666,7 +666,7 @@ Hadamard gate
    \begin{pmatrix}
    1 & 0\\
    0 & e^{-i \pi/4}
-   \end{pmatrix}= u1(-pi/4)
+   \end{pmatrix}= u1(-\pi/4)
 
 They can be added as below.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Corrects a missing backslash in the definition of the T dagger gate that was causing the math to render as the word "pi" instead of the symbol.


### Details and comments


