### PR TITLE
Documentation fix for broken link to jupyter_backend_tools.ipynb

### DIFF
--- a/docs/terra/backend_monitoring_tools.rst
+++ b/docs/terra/backend_monitoring_tools.rst
@@ -217,4 +217,5 @@ available to us, then we can use ``backend_overview()``
 
 There are also Jupyter magic equivalents that give more detailed
 information, as demonstrated here: `Jupyter tools for Monitoring jobs
-and backends <../../../../../qiskit-tutorials/blob/master/qiskit/jupyter/jupyter_backend_tools.ipynb>`__
+and backends
+<../../../../../qiskit-tutorials/blob/master/qiskit/jupyter/jupyter_backend_tools.ipynb>`__

--- a/docs/terra/backend_monitoring_tools.rst
+++ b/docs/terra/backend_monitoring_tools.rst
@@ -90,7 +90,7 @@ It is also possible to monitor the job using ``job_monitor`` in
 async-mode (Jupyter notebooks only). The job will be monitored in a
 separate thread, allowing you to continue to work in the notebook. For
 details see: `Jupyter tools for Monitoring jobs and
-backends <../jupyter/jupyter_backend_tools.ipynb>`__
+backends <../../../../../qiskit-tutorials/blob/master/qiskit/jupyter/jupyter_backend_tools.ipynb>`__
 
 Changing the interval of status updating
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -217,4 +217,4 @@ available to us, then we can use ``backend_overview()``
 
 There are also Jupyter magic equivalents that give more detailed
 information, as demonstrated here: `Jupyter tools for Monitoring jobs
-and backends <../jupyter/jupyter_backend_tools.ipynb>`__
+and backends <../../../../../qiskit-tutorials/blob/master/qiskit/jupyter/jupyter_backend_tools.ipynb>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
It seems the linked jupyter_backend_tools.ipynb now lives in a different repository, qiskit-tutorials. I have tested the link and believe I am linking to the correct topic, but pls verify.


### Details and comments
Page with broken links:
https://qiskit.org/documentation/terra/backend_monitoring_tools.html

Broken links:
https://qiskit.org/documentation/jupyter/jupyter_backend_tools.ipynb

Correct link:
https://github.com/Qiskit/qiskit-tutorials/blob/master/qiskit/jupyter/jupyter_backend_tools.ipynb
