### PR TITLE
Add documentation for the user config file

### DIFF
--- a/docs/terra/index.rst
+++ b/docs/terra/index.rst
@@ -11,3 +11,4 @@ Qiskit Terra Documentation
    Plotting Data in Qiskit <plotting_data_in_qiskit>
    Tools for Monitoring Backends <backend_monitoring_tools>
    Terra Parallel Tools <terra_parallel_tools>
+   Using User Config Files <user_config>

--- a/docs/terra/user_config.rst
+++ b/docs/terra/user_config.rst
@@ -1,0 +1,39 @@
+User Config Files
+=================
+
+When using Qiskit Terra there are several aspects of the library where Terra
+has opinionated defaults. These defaults are normally in the interest of
+supporting the least common demonitator between users. For example, the default
+backend for ``qiskit.visualization.circuit_drawer()``/``QuantumCircuit.draw()``
+is the text backend. However, depending on your local environment you may want
+to change these defaults to something better suited for your use case. This is
+what the user config file can be used for. It lets you optionally specify
+local defaults for these things
+
+
+Creating a User Config File
+---------------------------
+
+By default the user config file should be located in
+``~/.qiskit/settings.conf``. It is a ``.ini`` file that lists any options you'd
+like to change the defaults on. Right now there is only one supported option,
+``circuit_drawer`` which is used to set the default backend used when running
+the circuit drawer.
+
+For example, a ``settings.conf`` file with all the options set would look
+like::
+
+    [default]
+    circuit_drawer = latex
+
+In this file when you call the circuit drawer the default output will be
+``'latex'`` instead of ``'text'``.
+
+Alternative Locations for a User Config File
+--------------------------------------------
+
+The default location for the user config file is ``~/.qiskit/settings.conf``
+but if you want to store your user config file in a different location you
+can specify this with the ``QISKIT_SETTINGS`` environment variable. When
+``QISKIT_SETTINGS`` is set Qiskit Terra will try to use the value as the path
+to the user config file.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#2122 a new feature was added for having user
config files that let local environments override some default settings
for functions in terra. Right now this is just the circuit drawer
backend, but this will grow in the future. This commit adds
documentation on how to use this feature.

### Details and comments