### PR TITLE
Bump released package versions and set meta package version to 0.9.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,16 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+`0.9.0`_ - 2019-05-02
+=====================
+
+Changed
+-------
+
+- The qiskit-terra version increased to the next feature release 0.8.0.
+- The qiskit-aer version increased to the next feature release 0.2.0.
+- The qiskit-ignis version increased to the next release 0.1.1.
+
 
 `0.8.1`_ - 2019-05-01
 =====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,12 +21,17 @@ The format is based on `Keep a Changelog`_.
 `0.9.0`_ - 2019-05-02
 =====================
 
+Added
+-----
+
+- Added the qiskit-ibmq-provider package to the metapackage (#227).
+
 Changed
 -------
 
-- The qiskit-terra version increased to the next feature release 0.8.0.
-- The qiskit-aer version increased to the next feature release 0.2.0.
-- The qiskit-ignis version increased to the next release 0.1.1.
+- The qiskit-terra version increased to the next feature release 0.8.0 (#227).
+- The qiskit-aer version increased to the next feature release 0.2.0 (#227).
+- The qiskit-ignis version increased to the next release 0.1.1 (#227).
 
 
 `0.8.1`_ - 2019-05-01
@@ -85,7 +90,8 @@ Added
 
 - First release, includes qiskit-terra and qiskit-aer
 
-.. _UNRELEASED: https://github.com/Qiskit/qiskit-terra/compare/0.8.1...HEAD
+.. _UNRELEASED: https://github.com/Qiskit/qiskit-terra/compare/0.9.0...HEAD
+.. _0.9.0: https://github.com/Qiskit/qiskit/compare/0.8.1...0.9.0
 .. _0.8.1: https://github.com/Qiskit/qiskit/compare/0.8.0...0.8.1
 .. _0.8.0: https://github.com/Qiskit/qiskit/compare/0.7.3...0.8.0
 .. _0.7.3: https://github.com/Qiskit/qiskit/compare/0.7.2...0.7.3

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.develop import develop
 
-qiskit_terra = "qiskit_terra==0.7.2"
+qiskit_terra = "qiskit_terra==0.8.0"
 
 requirements = [
     qiskit_terra,
-    "qiskit-aer==0.1.1",
-    "qiskit-ignis==0.1.0"
+    "qiskit-aer==0.2.0",
+    "qiskit-ignis==0.1.1"
 ]
 
 
@@ -74,7 +74,7 @@ except:
 
 setup(
     name="qiskit",
-    version="0.8.1",
+    version="0.9.0",
     description="Software for developing quantum computing programs",
     long_description="Qiskit is a software development kit for writing "
                      "quantum computing experiments, programs, and "

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ qiskit_terra = "qiskit_terra==0.8.0"
 requirements = [
     qiskit_terra,
     "qiskit-aer==0.2.0",
+    "qiskit-ibmq-provider==0.1.1",
     "qiskit-ignis==0.1.1"
 ]
 

--- a/test/benchmarks/quantum_volume.py
+++ b/test/benchmarks/quantum_volume.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # =============================================================================
 
-# pylint: disable=no-member,invalid-name,missing-docstring
+# pylint: disable=no-member,invalid-name,missing-docstring,no-name-in-module
 # pylint: disable=attribute-defined-outside-init,unsubscriptable-object
 
 """Module for estimating quantum volume.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit bumps the version numbers for the newly released versions of
terra, aer, and ignis. It also bumps the version of the package to
reflect this change per the versioning policy.


### Details and comments


