### PR TITLE
Remove stray rebase line

### DIFF
--- a/docs/release_history.rst
+++ b/docs/release_history.rst
@@ -45,7 +45,6 @@ In addition there is also the introduction of the following new features:
 
 Upgrades
 --------
->>>>>>> Add notes about new compile workflow and adjust heading levels
 
 Please note that some backwards incompatible changes have been made during this
 release. The following notes contain infomation on how to adapt to these


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the rebasing of release notes when both #221 and #213 were
being merged a stray line from git rebase slipped into the release
history document. This commit removes this since it's not part of the
document and in there by mistake.

### Details and comments