### PR TITLE
Remove aqua and chemistry as separate paths from autodoc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - if: branch = master AND type = push
       python: "3.5"
       install:
-        - pip install qiskit-terra qiskit-aer qiskit-aqua qiskit-chemistry
+        - pip install qiskit
         - pip install -r requirements-dev.txt
       script: tools/deploy_documentation.sh
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@
 # environment variable with the same name (ie. "PATH_QISKIT=/a/b/c make doc"),
 # the environment variable value will take precedence.
 PATH_QISKIT ?= $(shell pip show qiskit-terra | grep Location | sed 's/Location: //')
-PATH_AQUA ?= $(shell pip show qiskit-aqua | grep Location | sed 's/Location: //')
-PATH_CHEMISTRY ?= $(shell pip show qiskit-chemistry | grep Location | sed 's/Location: //')
 
 autodoc_qiskit:
 ifneq ($(PATH_QISKIT), )
@@ -25,20 +23,8 @@ ifneq ($(PATH_QISKIT), )
 		$(PATH_QISKIT)/qiskit
 endif
 
-autodoc_aqua:
-ifneq ($(PATH_AQUA), )
-	sphinx-apidoc --output docs/autodoc --separate --implicit-namespaces --private --module-first -d 16 \
-		$(PATH_AQUA)/qiskit_aqua
-endif
-
-autodoc_chemistry:
-ifneq ($(PATH_CHEMISTRY), )
-	sphinx-apidoc --output docs/autodoc --separate --implicit-namespaces --private --module-first -d 16 \
-		$(PATH_CHEMISTRY)/qiskit_chemistry
-endif
-
-autodoc: autodoc_qiskit autodoc_aqua autodoc_chemistry
-ifneq ($(PATH_TERRA) $(PATH_AQUA) $(PATH_CHEMISTRY), )
+autodoc: autodoc_qiskit
+ifneq ($(PATH_TERRA), )
 	rm -f docs/autodoc/modules.rst
 endif
 

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -45,7 +45,8 @@ git rm -rf --ignore-unmatch $TARGET_DOC_DIR/*.html \
     $TARGET_DOC_DIR/aer \
     $TARGET_DOC_DIR/autodoc \
     $TARGET_DOC_DIR/aqua \
-    $TARGET_DOC_DIR/terra
+    $TARGET_DOC_DIR/terra \
+    $TARGET_DOC_DIR/ignis
 
 # Copy the new rendered files and add them to the commit.
 mkdir -p $TARGET_DOC_DIR


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Now that qiskit aqua and chemistry 0.5.0 have been released they have
their code off of the same qiskit namespace as the other packages. This
means the code in the makefile for building docs which generated
separate autodoc trees for the qiskit_aqua and qiskit_chemistry
namespaces is not needed anymore. Since when we install the qiskit
python package aqua and chemistry will be picked up by the search over
the qiskit namespace. This commit updates the makefile accordingly to
only run autodoc on the root qiskit namespace.

### Details and comments