### PR TITLE
Switch docs jobs to run on Xenial with Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ matrix:
     - python: "3.5"
       env: TOXENV=lint
     - if: branch = master AND type = push
-      python: "3.5"
+      os: linux
+      dist: xenial
+      python: "3.7"
+      sudo: true
       install:
         - pip install qiskit
         - pip install -r requirements-dev.txt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the process of trying to debug the floating point exception
encountered during the docs builds in #235 docs builds were run in all
our unit test environments. The python3.7 environment which runs on
xenial successfully built the docs. So instead of trying to get to the
bottom of why there is a floating point exception during the sphinx
build in the current job setup, this commit just switches to the same
node setup as the python 3.7 unit test env. This means switching to
an Ubuntu Xenial node and using Python 3.7 to run the docs builds.

### Details and comments


