### PR TITLE
Update the user config docs for all drawer backends

### DIFF
--- a/docs/terra/user_config.rst
+++ b/docs/terra/user_config.rst
@@ -27,7 +27,10 @@ like::
     circuit_drawer = latex
 
 In this file when you call the circuit drawer the default output will be
-``'latex'`` instead of ``'text'``.
+``'latex'`` instead of ``'text'``. You can use any of the valid circuit drawer
+backends as the value for this config, this includes ``text``, ``mpl``,
+``latex``, and ``latex_source``. These are the only valid values for the
+``circuit_drawer`` field.
 
 Alternative Locations for a User Config File
 --------------------------------------------

--- a/docs/terra/user_config.rst
+++ b/docs/terra/user_config.rst
@@ -24,10 +24,10 @@ For example, a ``settings.conf`` file with all the options set would look
 like::
 
     [default]
-    circuit_drawer = latex
+    circuit_drawer = mpl
 
 In this file when you call the circuit drawer the default output will be
-``'latex'`` instead of ``'text'``. You can use any of the valid circuit drawer
+``'mpl'`` instead of ``'text'``. You can use any of the valid circuit drawer
 backends as the value for this config, this includes ``text``, ``mpl``,
 ``latex``, and ``latex_source``. These are the only valid values for the
 ``circuit_drawer`` field.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the user config documentation to include all valid
values available for the one config option currently present in the user
config file. Previously it wasn't entirely clear that you could specify
mpl or latex_source to change the default circuit drawer backend to
those in their environment.

### Details and comments


