### PR TITLE
Fix a typo in QuantumCircuits docs

### DIFF
--- a/docs/terra/quantum_circuits.rst
+++ b/docs/terra/quantum_circuits.rst
@@ -145,7 +145,7 @@ properties of the ``QuantumCircuit``.
 
 .. code:: python
 
-  print(qc,qregs)
+  print(qc.qregs)
   print(qc.cregs)
 
 .. parsed-literal::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
There's a typo in the documentation, where a period should be instead of a comma.


### Details and comments
Didn't think this needs to be entered into the CHANGELOG, but I can add a note if necessary.
