### PR TITLE
Avoid using FakeMelbourne from qiskit/test

### DIFF
--- a/test/benchmarks/quantum_volume.py
+++ b/test/benchmarks/quantum_volume.py
@@ -24,7 +24,6 @@ See arXiv:1811.12926 [quant-ph]"""
 import numpy as np
 
 from qiskit.providers.basicaer import QasmSimulatorPy
-from qiskit.test.mock import FakeMelbourne
 
 try:
     from qiskit.mapper import two_qubit_kak
@@ -130,7 +129,10 @@ class QuantumVolumeBenchmark:
 
     def time_ibmq_backend_transpile(self, _, __):
         # Run with ibmq_16_melbourne configuration
-        backend = FakeMelbourne()
+        coupling_map = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
+                        [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],
+                        [11, 3], [11, 10], [11, 12], [12, 2], [13, 1], [13, 12]]
+
         transpile(self.circuit,
                   basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
                   coupling_map=backend.configuration().coupling_map)

--- a/test/benchmarks/quantum_volume.py
+++ b/test/benchmarks/quantum_volume.py
@@ -131,7 +131,8 @@ class QuantumVolumeBenchmark:
         # Run with ibmq_16_melbourne configuration
         coupling_map = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
                         [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],
-                        [11, 3], [11, 10], [11, 12], [12, 2], [13, 1], [13, 12]]
+                        [11, 3], [11, 10], [11, 12], [12, 2], [13, 1],
+                        [13, 12]]
 
         transpile(self.circuit,
                   basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],

--- a/test/benchmarks/quantum_volume.py
+++ b/test/benchmarks/quantum_volume.py
@@ -136,4 +136,4 @@ class QuantumVolumeBenchmark:
 
         transpile(self.circuit,
                   basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
-                  coupling_map=backend.configuration().coupling_map)
+                  coupling_map=coupling_map)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the previous update to the the quantum volume benchmarks the fake
melbourne class from the terra tests was used instead of hardcoding the
coupling map directly in the benchmark. However because this lives in
the terra tests python namespace it has a depedency on a bunch of test
requirements at import time (even though they're not used). This causes
the benchmarks to fail in a production environment because they do not
install the terra development/testing requirements in the venv used for
testing. To avoid this failure, this commit removes the fake backend
usage and switches to a hard coded coupling map which was just copied
from the backend code. [1]

### Details and comments

[1] https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/test/mock.py#L258-L260
