### PR TITLE
Cleanup terra install doc and fix broken links

### DIFF
--- a/docs/contributing_to_qiskit.rst
+++ b/docs/contributing_to_qiskit.rst
@@ -147,7 +147,7 @@ The following steps show the installation process for Ignis.
   pip install -e qiskit-ignis
 
 Install Terra from Source
---------------------------------
+-------------------------
 Installing from source requires that you have a c++ compiler on your system that supports
 c++-11.  On most Linux platforms, the necessary GCC compiler is already installed.
 
@@ -209,24 +209,26 @@ Install Qiskit Terra
 
     pip install .
 
-
-* To get the examples working, install and run them with the following commands.
+* If you want to install it in editable mode, meaning that code changes to the
+  project don't require a reinstall to be applied you can do this with:
 
 .. code:: sh
 
     pip install -e .
+
+* You can then run the code examples working after installing terra. You can
+  run the example with the following command.
+
+.. code:: sh
+
     python examples/python/using_qiskit_terra_level_0.py
 
 
 After you've installed Terra, you can install Aer as an add-on to run additional simulators.
 
-* `Qiskit Aer <https://github.com/Qiskit/qiskit-aer/blob/master/.github/
+* `Qiskit Aer <https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md>`__
+* `Qiskit Ignis <https://github.com/Qiskit/qiskit-ignis/blob/master/CONTRIBUTING.md>`_
+* `Qiskit Aqua <https://github.com/Qiskit/qiskit-aqua/blob/master/CONTRIBUTING.md>`__
+* `Qiskit Chemistry <https://github.com/Qiskit/qiskit-chemistry/blob/master/CONTRIBUTING.md>`__
+* `Qiskit IBMQ Provider <https://github.com/Qiskit/qiskit-ibmq-provider/blob/master/
   CONTRIBUTING.md>`__
-* `Qiskit Ignis <https://github.com/Qiskit/qiskit-ignis/blob/master/.github/
-  CONTRIBUTING.md>`_
-* `Qiskit Aqua <https://github.com/Qiskit/qiskit-aqua/blob/master/.github/
-  CONTRIBUTING.rst>`__
-* `Qiskit Chemistry <https://github.com/Qiskit/qiskit-chemistry/blob/master/
-  .github/CONTRIBUTING.rst>`__
-* `Qiskit IBMQ Provider <https://github.com/Qiskit/qiskit-ibmq-provider/blob/
-  master/.github/CONTRIBUTING.rst>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was one section of the terra install guide that was misleading,
you do not need to use an editable install to run the examples. An
editable install allows you to make changes to the repo and have that
take effect immediately without requiring an uninstall. [1][2] For
running examples it doesn't make a difference how you install terra. At
the same time the links at the bottom of the repo are updated to point
to the new locations for the CONTRIBUTING.md files.

### Details and comments

[1] https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs
[2] https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode
