### PR TITLE
Typos / Broken Links in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Qiskit is made up elements that each work together to enable quantum computing. This is a simple meta-package to install the elements of Qiskit altogether.
 
-## Installation 
+## Installation
 
 The best way of installing `qiskit` is using `pip`:
 
@@ -15,22 +15,22 @@ The best way of installing `qiskit` is using `pip`:
 $ pip install qiskit
 ```
 
-See [install](docs/install.rst) Qiskit for detailed instructions, how to use virtual environments, and 
+See [install](docs/install.rst) Qiskit for detailed instructions, how to use virtual environments, and
 build from source standalone versions of the individual Qiskit elements and components.
 
 ## Qiskit Details
 
-Qiskit consists of elements and components and it is our goal to have all the elements and components install 
+Qiskit consists of elements and components and it is our goal to have all the elements and components install
 using this mega package. However, currently some still are not included
 in the default pip and need to be installed following instructions in their individual packages (this will be fixed
 in the next update)
 
 ### Qiskit Elements
 
-The four elements of Qiskit are the essential parts that give Qiskit its power. 
+The four elements of Qiskit are the essential parts that give Qiskit its power.
 
-| Build   | Status | Version | Contribute | 
-| ---             | ---    | --- | --- | 
+| Build   | Status | Version | Contribute |
+| ---             | ---    | --- | --- |
 | [**Qiskit Terra**](https://qiskit.org/terra)   |  [![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-terra/master.svg?)](https://travis-ci.com/Qiskit/qiskit-terra)| [![](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?)](https://github.com/Qiskit/qiskit-terra/releases)  | [![](https://img.shields.io/github/forks/Qiskit/qiskit-terra.svg?)](https://github.com/Qiskit/qiskit-terra) |
 | [**Qiskit Aer**](https://qiskit.org/aer)   |  [![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-aer/master.svg?)](https://travis-ci.com/Qiskit/qiskit-aer) | [![](https://img.shields.io/github/release/Qiskit/qiskit-aer.svg?)](https://github.com/Qiskit/qiskit-aer/releases) | [![](https://img.shields.io/github/forks/Qiskit/qiskit-aer.svg?)](https://github.com/Qiskit/qiskit-aer) |
 | [**Qiskit Aqua**](https://qiskit.org/aqua) |  [![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-aqua/master.svg?)](https://travis-ci.com/Qiskit/qiskit-aqua) |  [![](https://img.shields.io/github/release/Qiskit/qiskit-aqua.svg?)](https://github.com/Qiskit/qiskit-aqua/releases) | [![](https://img.shields.io/github/forks/Qiskit/qiskit-aqua.svg?)](https://github.com/Qiskit/qiskit-aqua) |
@@ -40,7 +40,7 @@ The four elements of Qiskit are the essential parts that give Qiskit its power.
 
 Qiskit components are smaller self-contained parts of Qiskit that are needed for full functionality.
 
-| Build   | Status | Version | Contribute | 
+| Build   | Status | Version | Contribute |
 | ---             | ---    | --- | --- |
 | **Qiskit Tutorial**  | --- |  [![](https://img.shields.io/github/release/Qiskit/qiskit-tutorial.svg?)](https://github.com/Qiskit/qiskit-tutorial/releases)   | [![](https://img.shields.io/github/forks/Qiskit/qiskit-tutorial.svg?)](https://github.com/Qiskit/qiskit-tutorial) |
 | **Qiskit Chemistry** |  [![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-chemistry/master.svg?)](https://travis-ci.com/Qiskit/qiskit-chemistry) |  [![](https://img.shields.io/github/release/Qiskit/qiskit-chemistry.svg?)](https://github.com/Qiskit/qiskit-chemistry/releases)   | [![](https://img.shields.io/github/forks/Qiskit/qiskit-chemistry.svg?)](https://github.com/Qiskit/qiskit-chemistry) |
@@ -50,9 +50,9 @@ Qiskit components are smaller self-contained parts of Qiskit that are needed for
 ## Contribution Guidelines
 
 If you'd like to contribute to Qiskit, please take a look at our
-[contribution guidelines](.github/CONTRIBUTING.md). This project adheres to Qiskit's [code of conduct](.github/CODE_OF_CONDUCT.md). By participating, you are expect to uphold to this code.
+[contribution guidelines](CONTRIBUTING.md). This project adheres to Qiskit's [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expect to uphold to this code.
 
-We use [GitHub issues](https://github.com/Qiskit/qiskit/issues) for tracking requests and bugs. Please use our [slack](https://qiskit.slack.com) for discussion and simple questions. To join our Slack community use the [link](https://join.slack.com/t/qiskit/shared_invite/enQtNDc2NjUzMjE4Mzc0LTMwZmE0YTM4ZThiNGJmODkzN2Y2NTNlMDIwYWNjYzA2ZmM1YTRlZGQ3OGM0NjcwMjZkZGE0MTA4MGQ1ZTVmYzk). For questions that are more suited for a forum we use the Qiskit tag in the [Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/qiskit).
+We use [GitHub issues](https://github.com/Qiskit/qiskit/issues) for tracking requests and bugs. Please use our [slack](https://qiskit.slack.com) for discussion and simple questions. To join our Slack community use the [link](https://qiskit.slack.com/join/shared_invite/enQtNjQ5OTc5ODM1ODYyLTBlMWY1ZGJiYmZkNjliZTY4MTViNTQ3NzI2ZmU2MzQxZjlhZDZlYTAzZTNlMDU0ZjVmNzEyMzY3OGE1Y2UyNjk). For questions that are more suited for a forum we use the Qiskit tag in the [Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/qiskit).
 
 ## Next Steps
 


### PR DESCRIPTION
Fixed Broken links in README.md to CODE_OF_CONDUCT.md and CONTRIBUTING.md

fixed #335 

