### PR TITLE
Updated broken link to Contributing topic

### DIFF
--- a/docs/aqua/extending.rst
+++ b/docs/aqua/extending.rst
@@ -14,7 +14,7 @@ framework.
 .. topic:: Contribution Guidelines
 
     Any user who would like to contribute to Aqua should follow the Aqua `contribution
-    guidelines <https://github.com/QISKit/aqua/blob/master/.github/CONTRIBUTING.rst>`__.
+    guidelines <https://github.com/Qiskit/qiskit-aqua/blob/master/CONTRIBUTING.md>`__.
 
 Aqua exposes numerous extension points. Researchers and developers can contribute to Aqua
 by providing new components, which will be automatically discovered and loaded by Aqua at run time.


### PR DESCRIPTION
The current link to: https://github.com/QISKit/aqua/blob/master/.github/CONTRIBUTING.rst  seems to be broken. The following link seems to be the one to use: https://github.com/Qiskit/qiskit-aqua/blob/master/CONTRIBUTING.md

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The current link to: https://github.com/QISKit/aqua/blob/master/.github/CONTRIBUTING.rst  seems to be broken. 

### Details and comments

One the following page:
https://qiskit.org/documentation/aqua/extending.html#aqua-extending

The contribution guidelines link is broken:
https://github.com/QISKit/aqua/blob/master/.github/CONTRIBUTING.rst 

The following link seems to be the one to use: 
https://github.com/Qiskit/qiskit-aqua/blob/master/CONTRIBUTING.md

More info in this commit:
https://github.com/Qiskit/qiskit-aqua/commit/90156030e7b21a81618ffe99ee9277564e878e56#diff-6a3371457528722a734f3c51d9238c13
