### PR TITLE
Bump aqua version and prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,18 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 > -   **Fixed**: for any bug fixes.
 > -   **Security**: in case of vulnerabilities.
 
-[UNRELEASED](https://github.com/Qiskit/qiskit-terra/compare/0.10.4...HEAD)
+[UNRELEASED](https://github.com/Qiskit/qiskit-terra/compare/0.10.5...HEAD)
 ==========================================================================
+
+[0.10.5](https://github.com/Qiskit/qiskit/compare/0.10.4...0.10.5) - 2019-06-27
+===============================================================================
+
+Changed
+-------
+
+- Increased the qiskit-aqua version the latest release 0.5.2, which removes
+  the install dependency on pyeda
+
 
 [0.10.4](https://github.com/Qiskit/qiskit/compare/0.10.3...0.10.4) - 2019-06-17
 ===============================================================================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ author = 'Qiskit Development Team'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.10.4'
+release = '0.10.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1212,6 +1212,13 @@ This table tracks the meta-package versions and the version of each Qiskit eleme
      - qiskit-ibmq-provider
      - qiskit-aqua
      - qiskit-chemistry
+   * - 0.10.5
+     - 0.8.2
+     - 0.2.1
+     - 0.1.1
+     - 0.2.2
+     - 0.5.2
+     - 0.5.0
    * - 0.10.4
      - 0.8.2
      - 0.2.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "qiskit-aer==0.2.1",
     "qiskit-ibmq-provider==0.2.2",
     "qiskit-ignis==0.1.1",
-    "qiskit-aqua==0.5.1",
+    "qiskit-aqua==0.5.2",
     "qiskit-chemistry==0.5.0"
 ]
 
@@ -77,7 +77,7 @@ except:
 
 setup(
     name="qiskit",
-    version="0.10.4",
+    version="0.10.5",
     description="Software for developing quantum computing programs",
     long_description="Qiskit is a software development kit for writing "
                      "quantum computing experiments, programs, and "


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit bumps the aqua version to pull in the latest release 0.5.2,
which removes the install time requirement of pyeda. It also prepares
the qiskit meta-package version for release.

### Details and comments

Fixes #311
