### PR TITLE
Fix Aqua documentation links

### DIFF
--- a/docs/aqua/ai/qiskit_ai.rst
+++ b/docs/aqua/ai/qiskit_ai.rst
@@ -62,7 +62,7 @@ Classical Reference Algorithms for AI
 
 To produce reference values and compare and contrast results during experimentation,
 the Aqua library of :ref:`classical-reference-algorithms` also includes the
-:ref:`avm-rbf-kernel` classical algorithm.
+:ref:`svm-rbf-kernel` classical algorithm.
 
 -------------------------
 Contributing to Qiskit AI

--- a/docs/aqua/algorithms.rst
+++ b/docs/aqua/algorithms.rst
@@ -202,8 +202,8 @@ In summary, QAOA can be configured with the following parameters:
    If such list is not provided, QAOA will simply start with the all-zero vector.
 
    An optional ``Operator`` may be provided as a custom mixer Hamiltonian. This allows,
-   as discussed in `this paper <https://doi.org/10.1103/PhysRevApplied.5.034007>`
-   for quantum annealing, and in `this paper <https://arxiv.org/abs/1709.03489>` for QAOA,
+   as discussed in `this paper <https://doi.org/10.1103/PhysRevApplied.5.034007>`__
+   for quantum annealing, and in `this paper <https://arxiv.org/abs/1709.03489>`__ for QAOA,
    to run constrained optimization problems where the mixer constrains
    the evolution to a feasible subspace of the full Hilbert space.
 

--- a/docs/aqua/chemistry/qiskit_chemistry_execution.rst
+++ b/docs/aqua/chemistry/qiskit_chemistry_execution.rst
@@ -661,7 +661,7 @@ which only become enabled when the algorithm
 selected by the user supports them.
 For example, the ``variational_form`` section is enabled only
 if the user has chosen to execute the experiment using a variational algorithm, such as
-:ref:`vqe.
+:ref:`vqe`.
 The Qiskit Chemistry :ref:`qiskit-chemistry-gui` disables the ``variational_form``
 section for non-variational algorithms.
 The problem with the configuration of an initial state and a variational form is that

--- a/docs/aqua/circuit_collection.rst
+++ b/docs/aqua/circuit_collection.rst
@@ -4,256 +4,310 @@
 A Collection of Circuits and Gates for Building Higher Level Circuits, Components and Algorithm
 ===============================================================================================
 
-Aqua provides easy access to a collection of commonly used circuits and gates
+Aqua provides easy access to a collection of commonly used
+:ref:`collection-circuits` and :ref:`collection-gates`
 to be used as the building blocks for various components, algorithms and applications.
 The gates can be enabled by corresponding imports from ``qiskit.aqua.circuits.gates``
 and then directly invoked from ``QuantumCircuit`` objects.
 The circuits can be accessed by importing corresponding classes from ``qiskit.aqua.circuits``.
 
+.. _collection-gates:
 
+-----
+Gates
+-----
+
+The following gates are part of the collection:
+
+- :ref:`mct`
+- :ref:`rpt`
+- :ref:`mcmt`
+- :ref:`ch-gate`
+- :ref:`cry-gate`
+- :ref:`mcr-gates`
+- :ref:`mcu1-gate`
+- :ref:`logical-gates`
 
 .. _mct:
 
-.. topic:: Multiple-Control Toffoli (MCT) Gate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Multiple-Control Toffoli (MCT) Gate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The *Multiple-Control Toffoli (mct)* gate, as the name suggests, is
-    a generalization of the traditional Toffoli gate s.t. one target qubit is
-    controlled by an arbitrary number of control qubits for a NOT (`x`) operation.
-    The MCT gate can be used as the building block
-    for implementing various different quantum algorithms, such as Grover's search.
+The *Multiple-Control Toffoli (mct)* gate, as the name suggests, is
+a generalization of the traditional Toffoli gate s.t. one target qubit is
+controlled by an arbitrary number of control qubits for a NOT (`x`) operation.
+The MCT gate can be used as the building block
+for implementing various different quantum algorithms, such as Grover's search.
 
-    For the different numbers 0, 1, 2, … of controls, we have corresponding
-    quantum gates ``x``, ``cx``, ``ccx``, ... The first three are basic/well-known
-    quantum gates. In Aqua, ``mct`` provides support for arbitrary
-    numbers of controls, in particular, 3 or above.
+For the different numbers 0, 1, 2, … of controls, we have corresponding
+quantum gates ``x``, ``cx``, ``ccx``, ... The first three are basic/well-known
+quantum gates. In Aqua, ``mct`` provides support for arbitrary
+numbers of controls, in particular, 3 or above.
 
-    Currently four different implementation strategies are included: *basic*,
-    *basic-dirty-ancilla*, *advanced*, and *noancilla*.
-    The basic mode employs a textbook
-    implementation, where a series of ``ccx`` Toffoli gates are linked
-    together in a ``V`` shape to achieve the desired Multiple-Control Toffoli
-    operation. This mode requires :math:`n-2` ancillary qubits, where
-    :math:`n` is the number of controls.
-    The basic-dirty-ancilla mode is the same as the basic mode
-    except that it allows using dirty ancillary qubits,
-    whereas the basic mode requires clean ancillae.
-    For the advanced mode, the ``cccx``
-    and ``ccccx`` operations are achieved without needing ancillary
-    qubits. Multiple-Control Toffoli operations for higher
-    number of controls (5 and above) are implemented recursively using these
-    lower-number-of-control cases. For the noancilla mode, no ancillary
-    qubits are needed even for higher number of controls. This uses a
-    technique of spliting multiple-control Toffoli operations, which is
-    efficient up to 8 controls but gets inefficient in the number of required
-    basic gates for values above. This technique relies on ``mcu1``, see
-    :ref:`mcu1 gate <mcu1-gate>` for more information.
+Currently four different implementation strategies are included: *basic*,
+*basic-dirty-ancilla*, *advanced*, and *noancilla*.
+The basic mode employs a textbook
+implementation, where a series of ``ccx`` Toffoli gates are linked
+together in a ``V`` shape to achieve the desired Multiple-Control Toffoli
+operation. This mode requires :math:`n-2` ancillary qubits, where
+:math:`n` is the number of controls.
+The basic-dirty-ancilla mode is the same as the basic mode
+except that it allows using dirty ancillary qubits,
+whereas the basic mode requires clean ancillae.
+For the advanced mode, the ``cccx``
+and ``ccccx`` operations are achieved without needing ancillary
+qubits. Multiple-Control Toffoli operations for higher
+number of controls (5 and above) are implemented recursively using these
+lower-number-of-control cases. For the noancilla mode, no ancillary
+qubits are needed even for higher number of controls. This uses a
+technique of spliting multiple-control Toffoli operations, which is
+efficient up to 8 controls but gets inefficient in the number of required
+basic gates for values above. This technique relies on ``mcu1``, see
+:ref:`mcu1 gate <mcu1-gate>` for more information.
 
-    Aqua's MCT gate can be invoked from a ``QuantumCircuit`` object
-    using the ``mct`` API, which expects a list ``q_controls`` of control qubits,
-    a target qubit ``q_target``, and a list ``q_ancilla`` of ancillary qubits.
-    An optional keyword argument ``mode`` can also be passed in to indicate
-    whether the ``'basic'``, ``'basic-dirty-ancilla'``, ``'advanced'``,
-    or ``'noancilla'`` mode is chosen.
-    If omitted, this argument defaults to ``'basic'``.
+Aqua's MCT gate can be invoked from a ``QuantumCircuit`` object
+using the ``mct`` API, which expects a list ``q_controls`` of control qubits,
+a target qubit ``q_target``, and a list ``q_ancilla`` of ancillary qubits.
+An optional keyword argument ``mode`` can also be passed in to indicate
+whether the ``'basic'``, ``'basic-dirty-ancilla'``, ``'advanced'``,
+or ``'noancilla'`` mode is chosen.
+If omitted, this argument defaults to ``'basic'``.
 
 
 .. _rpt:
 
-.. topic:: Relative-Phase Toffoli Gates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Relative-Phase Toffoli Gates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Toffoli gates are helpful in implementing various other quantum circuits,
-    including the Multiple-Control Toffoli gates discussed above.
-    However, the usage of Toffoli gates might incur high costs in terms of circuit depth
-    depending on the particular implementations selected.
-    One approach that has been studied to mitigate this problem
-    is the use of Toffoli gates *up to a relative phase*,
-    for example, as discussed in `this paper <https://arxiv.org/abs/1508.03273>`__.
-    In Aqua, two such Relative-Phase Toffoli gates are provided,
-    the 2-Control ``rccx`` and the 3-Control ``rcccx``.
-    Upon import, both can be directly invoked from QuantumCircuit objects
-    similar to the traditional Toffoli ``ccx`` gate.
+Toffoli gates are helpful in implementing various other quantum circuits,
+including the Multiple-Control Toffoli gates discussed above.
+However, the usage of Toffoli gates might incur high costs in terms of circuit depth
+depending on the particular implementations selected.
+One approach that has been studied to mitigate this problem
+is the use of Toffoli gates *up to a relative phase*,
+for example, as discussed in `this paper <https://arxiv.org/abs/1508.03273>`__.
+In Aqua, two such Relative-Phase Toffoli gates are provided,
+the 2-Control ``rccx`` and the 3-Control ``rcccx``.
+Upon import, both can be directly invoked from QuantumCircuit objects
+similar to the traditional Toffoli ``ccx`` gate.
 
 
 .. _mcmt:
 
-.. topic:: Multiple-Control Multiple-Target (MCMT) Gate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Multiple-Control Multiple-Target (MCMT) Gate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The *Multiple-Control Multiple-Target (mcmt)* Gate, as the name suggests,
-    allows to generalize a single-control, single-target gate (such as `cz`) to
-    support multiple control qubits and multiple target qubits.
-    In other words, the single-control gate passed as argument is applied to all
-    the target qubits if all the control qubits are active.
+The *Multiple-Control Multiple-Target (mcmt)* Gate, as the name suggests,
+allows to generalize a single-control, single-target gate (such as `cz`) to
+support multiple control qubits and multiple target qubits.
+In other words, the single-control gate passed as argument is applied to all
+the target qubits if all the control qubits are active.
 
-    The kind of gate to apply can be passed as a parameter and should be a single
-    control gate already defined for a ``QuantumCircuit`` object (such as
-    ``QuantumCircuit.cz`` or ``QuantumCircuit.ch``).
+The kind of gate to apply can be passed as a parameter and should be a single
+control gate already defined for a ``QuantumCircuit`` object (such as
+``QuantumCircuit.cz`` or ``QuantumCircuit.ch``).
 
-    Currently, just one implementation strategy is implemented: *basic*. It
-    employs almost the same strategy adopted for the basic mode of `mct`:
-    multiple Toffoli gates are chained together to get the logical `AND` of
-    all the control qubits on a single ancilla qubit, which is then used as the
-    control of the single-control gate function.
+Currently, just one implementation strategy is implemented: *basic*. It
+employs almost the same strategy adopted for the basic mode of `mct`:
+multiple Toffoli gates are chained together to get the logical `AND` of
+all the control qubits on a single ancilla qubit, which is then used as the
+control of the single-control gate function.
 
-    This mode requires :math:`n-1` ancillary qubits, where :math:`n` is the
-    number of controls. Compare this with ``mct`` mode which uses :math:`n-2`
-    ancillary qubits for the same strategy. The difference is due to the fact
-    that in ``mct`` the chain ends with a single ``ccx`` writing on the target
-    qubit, while in ``mcmt`` the chain ends with the ``ccx`` writing on an
-    ancillary qubit, which is then used as the control qubit of the single-control
-    gate function.
+This mode requires :math:`n-1` ancillary qubits, where :math:`n` is the
+number of controls. Compare this with ``mct`` mode which uses :math:`n-2`
+ancillary qubits for the same strategy. The difference is due to the fact
+that in ``mct`` the chain ends with a single ``ccx`` writing on the target
+qubit, while in ``mcmt`` the chain ends with the ``ccx`` writing on an
+ancillary qubit, which is then used as the control qubit of the single-control
+gate function.
 
-    Aqua's mcmt operation can be invoked from a ``QuantumCircuit`` object
-    using the ``mcmt`` API, which expects a list ``q_controls`` of control qubits,
-    a list ``q_targets`` of target qubits, a list ``q_ancilla`` of ancillary qubits
-    that must be off and are promised to be off after the function call, and a
-    function ``single_control_gate_fun`` which is the generic function to
-    apply to the ``q_targets`` qubits. An optional keyword argument ``mode`` can
-    also be passed in to indicate the mode, but at the moment only the ``'basic'``
-    mode is supported. If omitted, this argument defaults to ``'basic'``.
+Aqua's mcmt operation can be invoked from a ``QuantumCircuit`` object
+using the ``mcmt`` API, which expects a list ``q_controls`` of control qubits,
+a list ``q_targets`` of target qubits, a list ``q_ancilla`` of ancillary qubits
+that must be off and are promised to be off after the function call, and a
+function ``single_control_gate_fun`` which is the generic function to
+apply to the ``q_targets`` qubits. An optional keyword argument ``mode`` can
+also be passed in to indicate the mode, but at the moment only the ``'basic'``
+mode is supported. If omitted, this argument defaults to ``'basic'``.
 
 
 .. _ch-gate:
 
-.. topic:: Controlled-Hadamard Gate
+^^^^^^^^^^^^^^^^^^^^^^^^
+Controlled-Hadamard Gate
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The controlled-Hadamard, or ``ch``, gate is already provided by Terra,
-    but it uses two ``cx`` gates in its implementation.
-    Aqua's ``ch`` gate only uses a single ``cx`` and is thus more efficient.
-    Upon import, Aqua's ``ch`` will automatically replace Terra's ``ch`` with no invocation difference.
+The controlled-Hadamard, or ``ch``, gate is already provided by Terra,
+but it uses two ``cx`` gates in its implementation.
+Aqua's ``ch`` gate only uses a single ``cx`` and is thus more efficient.
+Upon import, Aqua's ``ch`` will automatically replace Terra's ``ch`` with no
+invocation difference.
 
 
 .. _cry-gate:
 
-.. topic:: Controlled-RY Gate
+^^^^^^^^^^^^^^^^^^
+Controlled-RY Gate
+^^^^^^^^^^^^^^^^^^
 
-    The controlled-RY, or ``cry``, gate takes as input a rotation angle as well as the control and target qubits.
-    Upon import, Aqua's ``cry`` can be directly invoked from QuantumCircuit objects.
+The controlled-RY, or ``cry``, gate takes as input a rotation angle as well as the
+control and target qubits.
+Upon import, Aqua's ``cry`` can be directly invoked from QuantumCircuit objects.
 
 
 .. _mcr-gates:
 
-.. topic:: Multiple-Control Rotation (MCRX, MCRY, MCRZ) Gates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Multiple-Control Rotation (MCRX, MCRY, MCRZ) Gates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The *Multiple-Control Rotation (mcrx, mcry, mcrz)* gates, implements
-    rotations around X-, Y-, and Z-axis on a single target qubit with an
-    arbitrary number of control qubits. The MCR operations take one rotation
-    angle as input parameter. The ``mcry`` gate supports two modes of
-    operation: *basic* and *noancilla*. Mode *basic* takes an
-    additional ancillary register to perform the rotation. See :ref:`mct
-    gate <mct>` for more information. In mode *noancilla* no ancillary
-    qubits are needed. This is the standard mode for ``mcrx`` and ``mcrz``
-    gates. It is efficiently implemented by using a grey code sequence for up
-    to 8 control qubits. For larger number of controls this implementation
-    gets very inefficient.
+The *Multiple-Control Rotation (mcrx, mcry, mcrz)* gates, implements
+rotations around X-, Y-, and Z-axis on a single target qubit with an
+arbitrary number of control qubits. The MCR operations take one rotation
+angle as input parameter. The ``mcry`` gate supports two modes of
+operation: *basic* and *noancilla*. Mode *basic* takes an
+additional ancillary register to perform the rotation. See :ref:`mct
+gate <mct>` for more information. In mode *noancilla* no ancillary
+qubits are needed. This is the standard mode for ``mcrx`` and ``mcrz``
+gates. It is efficiently implemented by using a grey code sequence for up
+to 8 control qubits. For larger number of controls this implementation
+gets very inefficient.
 
-    Aqua's ``mcrx``, ``mcry``, and ``mcrz`` operations can be invoked from a
-    ``QuantumCircuit`` object and expect a list ``control_qubits`` of control
-    qubits and a target qubit ``target_qubit`` as well as an angle ``theta``
-    for the ``mcrx`` and ``mcry`` operation or ``lam`` for the ``mcrz``
-    operation.
+Aqua's ``mcrx``, ``mcry``, and ``mcrz`` operations can be invoked from a
+``QuantumCircuit`` object and expect a list ``control_qubits`` of control
+qubits and a target qubit ``target_qubit`` as well as an angle ``theta``
+for the ``mcrx`` and ``mcry`` operation or ``lam`` for the ``mcrz``
+operation.
 
 
 .. _mcu1-gate:
 
-.. topic:: Multiple-Control U1 (MCU1) Gate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Multiple-Control U1 (MCU1) Gate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The *Multiple-Control Rotation (mcu1)* gate, implements a U1 (`u1`)
-    rotation (phase rotation) on a single target qubit with an arbitrary number
-    of control qubits. The MCU1 operation takes one rotation angle as input
-    parameter. No ancillary qubits are needed. It is efficiently implemented
-    by using a grey code sequence for up to 8 control qubits. For larger
-    number of controls this implementation gets very inefficient.
+The *Multiple-Control Rotation (mcu1)* gate, implements a U1 (`u1`)
+rotation (phase rotation) on a single target qubit with an arbitrary number
+of control qubits. The MCU1 operation takes one rotation angle as input
+parameter. No ancillary qubits are needed. It is efficiently implemented
+by using a grey code sequence for up to 8 control qubits. For larger
+number of controls this implementation gets very inefficient.
 
-    Aqua's ``mcu1`` operation can be invoked from a ``QuantumCircuit``
-    object and expect a list ``control_qubits`` of control qubits and a target
-    qubit ``target_qubit`` as well as an angle ``lam``.
+Aqua's ``mcu1`` operation can be invoked from a ``QuantumCircuit``
+object and expect a list ``control_qubits`` of control qubits and a target
+qubit ``target_qubit`` as well as an angle ``lam``.
 
 
 .. _logical-gates:
 
-.. topic:: Boolean Logical Gates
+^^^^^^^^^^^^^^^^^^^^^
+Boolean Logical Gates
+^^^^^^^^^^^^^^^^^^^^^
 
-    Aqua also provides the logical *AND* and *OR* gates to mirror the corresponding classic logical operations.
-    *OR* gates are converted to *AND* gates using De Morgan's Law.
-    *AND* gates are implemented using :ref:`mct gate <mct>`.
+Aqua also provides the logical *AND* and *OR* gates to mirror the corresponding classic
+logical operations.
+*OR* gates are converted to *AND* gates using De Morgan's Law.
+*AND* gates are implemented using :ref:`mct gate <mct>`.
 
-    The ``AND`` and ``OR`` gates can be invoked from a ``QuantumCircuit`` object.
-    They both expect a ``qr_variables`` register holding the variable qubits,
-    a ``qb_target`` qubit for holding the result,
-    a ``qr_ancillae`` register to use as ancilla,
-    an optional ``flags`` list of ``+1``, ``0``, or ``-1`` values
-    indicating the signs or omissions of the variable qubits,
-    and an optional ``mct_mode`` flag for specifying the mode to use for ``mct``.
+The ``AND`` and ``OR`` gates can be invoked from a ``QuantumCircuit`` object.
+They both expect a ``qr_variables`` register holding the variable qubits,
+a ``qb_target`` qubit for holding the result,
+a ``qr_ancillae`` register to use as ancilla,
+an optional ``flags`` list of ``+1``, ``0``, or ``-1`` values
+indicating the signs or omissions of the variable qubits,
+and an optional ``mct_mode`` flag for specifying the mode to use for ``mct``.
+
+
+.. _collection-circuits:
+
+--------
+Circuits
+--------
+
+The following circuits are part of the collection:
+
+- :ref:`logical-circuits`
+- :ref:`fourier-transform-circuits`
+- :ref:`statevector_circuit`
 
 
 .. _logical-circuits:
 
-.. topic:: Boolean Logical Circuits
+^^^^^^^^^^^^^^^^^^^^^^^^
+Boolean Logical Circuits
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Aqua provides a simple set of tools for constructing circuits
-    from simple Boolean logical expressions.
-    Currently three types of expressions are supported:
-    Conjunctive Normal Forms (``CNF``), Disjunctive Normal Forms (``DNF``), and
-    Exclusive Sum of Products (``ESOP``).
-    They are also used internally by Aqua for constructing various :ref:`oracles`.
-    For initialization of each of the three types of objects,
-    the corresponding logical expression
-    can be specified as a tuple corresponding to the Abstract Syntax Tree (AST)
-    of the desired expression,
-    where each literal's absolute value indicates a variable,
-    and a negative sign indicates the negation of the corresponding variable.
-    The logical operations represented by the inner and outer lists
-    depend on the particular type (CNF, DNF, or ESOP) of objects being created.
-    For example, below is the AST for a simple CNF expression:
+Aqua provides a simple set of tools for constructing circuits
+from simple Boolean logical expressions.
+Currently three types of expressions are supported:
+Conjunctive Normal Forms (``CNF``), Disjunctive Normal Forms (``DNF``), and
+Exclusive Sum of Products (``ESOP``).
+They are also used internally by Aqua for constructing various :ref:`oracles`.
+For initialization of each of the three types of objects,
+the corresponding logical expression
+can be specified as a tuple corresponding to the Abstract Syntax Tree (AST)
+of the desired expression,
+where each literal's absolute value indicates a variable,
+and a negative sign indicates the negation of the corresponding variable.
+The logical operations represented by the inner and outer lists
+depend on the particular type (CNF, DNF, or ESOP) of objects being created.
+For example, below is the AST for a simple CNF expression:
 
-    .. code:: python
+.. code:: python
 
-      ('and',
-        ('or', ('lit', 1), ('lit', -2)),
-        ('or', ('lit', -1), ('lit', 2)))
+  ('and',
+    ('or', ('lit', 1), ('lit', -2)),
+    ('or', ('lit', -1), ('lit', 2)))
 
-    The ``CNF``, ``DNF``, and ``ESOP`` objects, upon the aforementioned AST initialization,
-    can generate their corresponding circuits from the API call ``construct_circuit``,
-    which takes a ``circuit`` object to extend from,
-    a ``variable_register`` for holding the variables of the logic expression,
-    a ``clause_register`` for holding the intermediate results of all clauses of the expression,
-    an ``output_register`` for holding the result,
-    an ``ancillary_register`` for all other ancillae,
-    and an ``mct_mode`` flag for specifying the mode to use for ``mct``.
-    All these arguments are optional can will be properly handled if omitted.
+The ``CNF``, ``DNF``, and ``ESOP`` objects, upon the aforementioned AST initialization,
+can generate their corresponding circuits from the API call ``construct_circuit``,
+which takes a ``circuit`` object to extend from,
+a ``variable_register`` for holding the variables of the logic expression,
+a ``clause_register`` for holding the intermediate results of all clauses of the expression,
+an ``output_register`` for holding the result,
+an ``ancillary_register`` for all other ancillae,
+and an ``mct_mode`` flag for specifying the mode to use for ``mct``.
+All these arguments are optional can will be properly handled if omitted.
 
 
 .. _fourier-transform-circuits:
 
-.. topic:: Quantum Fourier Transform Circuits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Quantum Fourier Transform Circuits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Quantum Fourier Transform is another technique commonly used in quantum algorithms,
-    for example, Phase Estimation and the Shor's factoring algorithm.
-    The ``FourierTransformCircuits`` class in Aqua's ``circuits`` library
-    is capable of constructing, for any specified number ``num_qubits`` of qubits,
-    both the normal quantum Fourier transform (qft) circuits
-    and the *inverse* quantum Fourier transform (iqft) circuits,
-    as can be specified by the ``inverse`` Boolean flag.
-    For each, an ``approximation_degree`` can also be specified
-    to build the approximation circuits with the desired approximation degree.
+Quantum Fourier Transform is another technique commonly used in quantum algorithms,
+for example, Phase Estimation and the Shor's factoring algorithm.
+The ``FourierTransformCircuits`` class in Aqua's ``circuits`` library
+is capable of constructing, for any specified number ``num_qubits`` of qubits,
+both the normal quantum Fourier transform (qft) circuits
+and the *inverse* quantum Fourier transform (iqft) circuits,
+as can be specified by the ``inverse`` Boolean flag.
+For each, an ``approximation_degree`` can also be specified
+to build the approximation circuits with the desired approximation degree.
 
-    Besides being directly exposed as circuits,
-    ``qft`` and ``iqft`` are also accessible as Aqua's pluggable ``components``.
-    More detailed discussion on quantum Fourier transform can be found at
-    :ref:`iqfts`.
+Besides being directly exposed as circuits,
+``qft`` and ``iqft`` are also accessible as Aqua's pluggable ``components``.
+More detailed discussion on quantum Fourier transform can be found at
+:ref:`iqfts`.
 
 
 .. _statevector_circuit:
 
-.. topic:: Arbitrary State Vector Circuit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Arbitrary State Vector Circuit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The circuit library also includes the ability to construct circuits from arbitrary state vectors,
-    via the ``StateVectorCircuit`` class,
-    which can be initialized using any arbitrary input state vector.
-    The ``construct_circuit`` method,
-    which takes optional ``circuit`` and ``register`` parameters,
-    can then build the corresponding circuit
-    using the basis ``u1``, ``u2``, ``u3``, ``cx``, and ``id`` gates.
-    This functionality is also exposed via
-    the ``CUSTOM`` mode of Aqua's ``InitialState`` pluggable component,
-    which is detailed at :ref:`custom-initial-states`.
+The circuit library also includes the ability to construct circuits from arbitrary
+state vectors, via the ``StateVectorCircuit`` class,
+which can be initialized using any arbitrary input state vector.
+The ``construct_circuit`` method,
+which takes optional ``circuit`` and ``register`` parameters,
+can then build the corresponding circuit
+using the basis ``u1``, ``u2``, ``u3``, ``cx``, and ``id`` gates.
+This functionality is also exposed via
+the ``CUSTOM`` mode of Aqua's ``InitialState`` pluggable component,
+which is detailed at :ref:`custom-initial-states`.

--- a/docs/aqua/index.rst
+++ b/docs/aqua/index.rst
@@ -13,7 +13,8 @@ applications:
 :ref:`aqua-chemistry`, :ref:`aqua-ai`, :ref:`aqua-optimization` and
 :ref:`aqua-finance`.
 Finally, :ref:`aqua-tutorials` is a companion library of notebooks, input files and sample code
-made available in the form of a `GitHub repository <https://github.com/Qiskit/aqua-tutorials>`__.
+which are available from the
+`Qiskit Tutorials GitHub repository <https://github.com/Qiskit/qiskit-tutorials>`__.
 
 This part of the documentation will first cover Aqua as a library of quantum applications,
 and then the domain-specific applications of Aqua: Chemistry, AI and Optimization.

--- a/docs/aqua/initial_states.rst
+++ b/docs/aqua/initial_states.rst
@@ -65,7 +65,7 @@ and a trial state to be evolved by the :ref:`qpe` algorithm.
 For example, when the transformation type of a chemistry operator is set to be particle hole,
 then the configuration of the initial qubit state offsetting the computation of the final result
 should be set to be the Hartree-Fock energy of the molecule in the
-:ref:`aqua-chemistry-input-file`. Hartree-Fock is also the preferred initial state when using the
+:ref:`qiskit-chemistry-input-file`. Hartree-Fock is also the preferred initial state when using the
 :ref:`uccsd` and :ref:`swaprz` variational forms.
 
 The following parameters allow
@@ -128,17 +128,17 @@ the Hartree-Fock initial state to be configured:
 .. note::
 
     When the ``auto_substitutions`` flag in the ``problem`` section of the
-    :ref:`aqua-chemistry-input-file`
+    :ref:`qiskit-chemistry-input-file`
     is set to ``True``, which is the default, the values of parameters
-    ``num_particles`` and ``num_orbitals`` are automatically computed by Aqua Chemistry
+    ``num_particles`` and ``num_orbitals`` are automatically computed by Qiskit Chemistry
     when ``Hartree-Fock`` is selected as the value of the ``name`` parameter in the
     ``InitialState`` section. As such, their configuration is disabled; the user will not be
     required, or even allowed, to assign values to these two parameters. This is also reflected in
-    the :ref:`aqua-chemistry-gui`, where these parameters will be grayed out and uneditable as
+    the :ref:`qiskit-chemistry-gui`, where these parameters will be grayed out and uneditable as
     long as ``auto_substitutions`` is set to ``True`` in the ``problem`` section. Furthermore,
-    Aqua Chemistry automatically sets parameters ``qubit_mapping`` and ``two_qubit_reduction`` in
+    Qiskit Chemistry automatically sets parameters ``qubit_mapping`` and ``two_qubit_reduction`` in
     section ``initial_state`` when ``HartreeFock`` is selected as the value of the ``name``
-    parameter.  Specifically, Aqua Chemistry sets ``qubit_mapping`` and ``two_qubit_reduction``
+    parameter.  Specifically, Qiskit Chemistry sets ``qubit_mapping`` and ``two_qubit_reduction``
     to the values the user assigned to them in the ``operator`` section
     of the input file in order to enforce parameter/value matching across these different
     sections.  As a result, the user will only have to configure ``qubit_mapping``

--- a/docs/aqua/neural_networks.rst
+++ b/docs/aqua/neural_networks.rst
@@ -43,8 +43,7 @@ Classical Discriminator
 This discriminator is given by a PyTorch neural network. Please note that PyTorch must be installed.
 For installation instructions see https://pytorch.org/get-started/locally/.
 
-The network is targeted at being used as part of the
-:ref:`Quantum Generative Adversarial Network (qGAN)` algorithm.
+The network is targeted at being used as part of the :ref:`qgan` algorithm.
 Please refer to `qGAN <https://arxiv.org/abs/1904.00043>`__  for further details on this algorithm.
 The discriminator takes an input vector where the number of represented features
 :math:`n_features \geq 1` and outputs a label for the data sample, i.e. true/fake.
@@ -86,8 +85,7 @@ Numpy Discriminator
 This discriminator is given by a NumPy neural network.
 
 
-The network is targeted at being used as part of the
-:ref:`Quantum Generative Adversarial Network (qGAN)` algorithm.
+The network is targeted at being used as part of the :ref:`qgan` algorithm.
 Please refer to `qGAN <https://arxiv.org/abs/1904.00043>`__  for further details on this algorithm.
 The discriminator takes an input vector where the number of represented features
 :math:`n_features \geq 1` and outputs a label for the data sample, i.e. true/fake.
@@ -128,8 +126,7 @@ Quantum Generator
 ----------------------
 
 This generator is given by a variational quantum circuit, see :ref:`variational-forms`.
-The network is targeted at being used as part of the
-:ref:`Quantum Generative Adversarial Network (qGAN)` algorithm.
+The network is targeted at being used as part of the :ref:`qgan` algorithm.
 Please refer to `qGAN <https://arxiv.org/abs/1904.00043>`__  for further details on this algorithm.
 
 The quantum generator generates outputs data samples which are fitted to a data grid.
@@ -167,7 +164,7 @@ is set to ``QuantumGenerator``:
 
   The generator circuit must either be given as UnivariateVariationalDistribution for
   univariate data or as MultivariateVariationalDistribution for multivariate data.
-  See :ref:`_random-distributions`.
+  See :ref:`random-distributions`.
 
 
 - Initial parameters used for the generator circuit:

--- a/docs/aqua/optimizers.rst
+++ b/docs/aqua/optimizers.rst
@@ -8,10 +8,10 @@ Aqua  contains a variety of classical optimizers for
 use by quantum variational algorithms, such as :ref:`vqe`.
 Logically, these optimizers can be divided into two categories:
 
-- :ref:`Local Optimizers`: Given an optimization problem, a *local optimizer* is a function that
+- :ref:`local-optimizers`: Given an optimization problem, a *local optimizer* is a function that
   attempts to find an optimal value within the neighboring set of a candidate solution.
 
-- :ref:`Global Optimizers`: Given an optimization problem, a *global optimizer* is a function that
+- :ref:`global-optimizers`: Given an optimization problem, a *global optimizer* is a function that
   attempts to find an optimal value among all possible solutions.
 
 
@@ -45,27 +45,26 @@ This section presents the classical local optimizers made available in Aqua.
 These optimizers are meant to be used in conjunction with quantum variational
 algorithms:
 
-- :ref:`ADAM`
-- :ref:`Analytic Quantum Gradient Descent (AQGD)`
-- :ref:`Conjugate Gradient (CG) Method`
-- :ref:`Constrained Optimization BY Linear Approximation (COBYLA)`
-- :ref:`Limited-memory Broyden-Fletcher-Goldfarb-Shanno Bound (L-BFGS-B)`
-- :ref:`Nelder-Mead`
-- :ref:`Parallel Broyden-Fletcher-Goldfarb-Shann (P-BFGS)`
-- :ref:`Powell`
-- :ref:`Sequential Least SQuares Programming (SLSQP)`
-- :ref:`Simultaneous Perturbation Stochastic Approximation (SPSA)`
-- :ref:`Truncated Newton (TNC)`
+- :ref:`adam_amsgrad`
+- :ref:`aqgd`
+- :ref:`cg`
+- :ref:`cobyla`
+- :ref:`l-bfgs-b`
+- :ref:`nelder-mead`
+- :ref:`p-bfgs`
+- :ref:`powell`
+- :ref:`slsqp`
+- :ref:`spsa`
+- :ref:`tnc`
 
-Except for :ref:`ADAM`, :ref:`Analytic Quantum Gradient Descent (AQGD)` and
-:ref:`Parallel Broyden-Fletcher-Goldfarb-Shann (P-BFGS)`, all these
+Except for :ref:`adam_amsgrad`, :ref:`aqgd` and :ref:`p-bfgs`, all these
 optimizers are directly based on the ``scipy.optimize.minimize`` optimization function in the
 `SciPy <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html>`__
 Python library. They all have a common pattern for parameters. Specifically, the ``tol``
 parameter, whose value must be a ``float`` indicating *tolerance for termination*,
 is from the ``scipy.optimize.minimize``  method itself, while the remaining parameters are
-from the `options
-dictionary <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.show_options.html>`__,
+from the `options dictionary
+<https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.show_options.html>`__,
 which may be referred to for further information.
 
 .. topic:: Transparent Parallelization of Gradient-based Local Opitmizers
@@ -265,8 +264,8 @@ The following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to AQGD declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and
-   loads it, is ``AQGD``.
+   When referring to AQGD declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``AQGD``.
 
 ----
 
@@ -329,8 +328,8 @@ The following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to CG declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``CG``.
+   When referring to CG declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``CG``.
 
 .. _cobyla:
 
@@ -372,13 +371,13 @@ COBYLA supports the following parameters:
 
         tol : float
 
-   This parameter is optional.  If specified, the value of this parameter must be of type ``float``, otherwise, it is set to ``None``.
-   The default is ``None``.
+   This parameter is optional.  If specified, the value of this parameter must be of type ``float``,
+   otherwise, it is set to ``None``. The default is ``None``.
 
 .. topic:: Declarative Name
 
-   When referring to COBYLA declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``COBYLA``.
+   When referring to COBYLA declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``COBYLA``.
 
 .. _l-bfgs-b:
 
@@ -424,7 +423,7 @@ The following parameters are supported:
 
    A positive ``int`` value is expected.  The default is ``10``.
 
--  An ``int`` value controlling the frequency of the printed output showing the  optimizer's
+-  An ``int`` value controlling the frequency of the printed output showing the optimizer's
    operations:
 
    .. code:: python
@@ -447,8 +446,8 @@ The following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to L-BFGS-B declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``L_BFGS_B``.
+   When referring to L-BFGS-B declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``L_BFGS_B``.
 
 .. _nelder-mead:
 
@@ -508,8 +507,8 @@ The following parameters are supported:
 
        tol : float
 
-   This parameter is optional.  If specified, the value of this parameter must be of type ``float``, otherwise, it is  ``None``.
-   The default is ``None``.
+   This parameter is optional.  If specified, the value of this parameter must be of type ``float``,
+   otherwise, it is  ``None``. The default is ``None``.
 
    .. code:: python
 
@@ -521,8 +520,8 @@ The following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to Nelder-Mead declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``NELDER_MEAD``.
+   When referring to Nelder-Mead declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``NELDER_MEAD``.
 
 .. _p-bfgs:
 
@@ -620,13 +619,13 @@ The following parameters are supported:
 
        tol : float
 
-   This parameter is optional.  If specified, the value of this parameter must be of type ``float``, otherwise, it is  ``None``.
-   The default is ``None``.
+   This parameter is optional.  If specified, the value of this parameter must be of type ``float``,
+   otherwise, it is  ``None``. The default is ``None``.
 
 .. topic:: Declarative Name
 
-   When referring to Powell declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``POWELL``.
+   When referring to Powell declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``POWELL``.
 
 .. _slsqp:
 
@@ -675,8 +674,8 @@ The following parameters are supported:
 
        tol : float
 
-   This parameter is optional.  If specified, the value of this parameter must be a ``float``, otherwise, it is  ``None``.
-   The default is ``None``.
+   This parameter is optional.  If specified, the value of this parameter must be a ``float``,
+   otherwise, it is  ``None``. The default is ``None``.
 
 -  Step size used for numerical approximation of the Jacobian.
 
@@ -688,8 +687,8 @@ The following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to SLSQP declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``SLSQP``.
+   When referring to SLSQP declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``SLSQP``.
 
 .. _spsa:
 
@@ -713,8 +712,8 @@ measurements of the objective function, regardless of the dimension of the optim
 
     SPSA can be used in the presence of noise, and it is therefore indicated in situations
     involving measurement uncertainty on a quantum computation when finding a minimum. If you are
-    executing a variational algorithm using a Quantum ASseMbly Language (QASM) simulator or a real device,
-    SPSA would be the most recommended choice among the optimizers provided here.
+    executing a variational algorithm using a Quantum ASseMbly Language (QASM) simulator or a real
+    device, SPSA would be the most recommended choice among the optimizers provided here.
 
 The optimization process includes a calibration phase, which requires additional
 functional evaluations.  Overall, the following parameters are supported:
@@ -735,7 +734,8 @@ functional evaluations.  Overall, the following parameters are supported:
         save_steps = 1 | 2 | ...
 
    A positive ``int`` value is expected.
-   SPSA will store optimization outcomes every ``save_steps`` trial steps.  The default value is ``1``.
+   SPSA will store optimization outcomes every ``save_steps`` trial steps.
+   The default value is ``1``.
 
 -  The number of last updates of the variables to average on for the
    final objective function:
@@ -793,8 +793,8 @@ functional evaluations.  Overall, the following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to SPSA declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``SPSA``.
+   When referring to SPSA declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``SPSA``.
 
 .. _tnc:
 
@@ -804,7 +804,7 @@ Truncated Newton (TNC)
 TNC uses a truncated Newton algorithm to minimize a function with
 variables subject to bounds. This algorithm uses gradient information;
 it is also called Newton Conjugate-Gradient. It differs from the
-:ref:`Conjugate Gradient (CG) Method` method as it wraps a C implementation and
+:ref:`cg` method as it wraps a C implementation and
 allows each variable to be given upper and lower bounds.
 
 The following parameters are supported:
@@ -867,8 +867,8 @@ The following parameters are supported:
 
         tol : float
 
-   This parameter is optional.  If specified, the value of this parameter must be a ``float``, otherwise, it is  ``None``.
-   The default is ``None``
+   This parameter is optional. If specified, the value of this parameter must be a ``float``,
+   otherwise, it is  ``None``. The default is ``None``
 
 -  Step size used for numerical approximation of the Jacobian.
    .. code:: python
@@ -879,16 +879,16 @@ The following parameters are supported:
 
 .. topic:: Declarative Name
 
-   When referring to TNC declaratively inside Aqua, its code ``name``, by which Aqua dynamically discovers and loads it,
-   is ``TNC``.
+   When referring to TNC declaratively inside Aqua, its code ``name``,
+   by which Aqua dynamically discovers and loads it, is ``TNC``.
 
 .. _global-optimizers:
 
 -----------------
 Global Optimizers
 -----------------
-Aqua supports a number of classical global optimizers,
-all based on the open-source `NonLinear optimization (NLopt) library <https://nlopt.readthedocs.io>`__.
+Aqua supports a number of classical global optimizers, all based on the open-source
+`NonLinear optimization (NLopt) library <https://nlopt.readthedocs.io>`__.
 Each of these optimizers uses the corresponding named optimizer from NLopt.
 This package has native code implementations and must be
 installed locally for these global optimizers to be accessible by Aqua.
@@ -900,8 +900,8 @@ in the ``nlopt`` subfolder of the ``optimizers`` folder.
     The `NLopt download and installation instructions <https://nlopt.readthedocs.io/en/latest/#download-and-installation>`__
     describe how to install NLopt.
 
-    If you running Aqua on Windows, then you might want to refer to the specific `instructions for
-    NLopt on Windows <https://nlopt.readthedocs.io/en/latest/NLopt_on_Windows/>`__.
+    If you running Aqua on Windows, then you might want to refer to the specific
+    `instructions for NLopt on Windows <https://nlopt.readthedocs.io/en/latest/NLopt_on_Windows/>`__.
 
     If you are running Aqua on a Unix-like system, first ensure that your environment is set
     to the Python executable for which the qiskit_aqua package is installed and running.
@@ -914,9 +914,10 @@ in the ``nlopt`` subfolder of the ``optimizers`` folder.
         make
         sudo make install
 
-    The above makes and installs the shared libraries and Python interface in `/usr/local`. To have these be used
-    by Aqua, the following commands can be entered to augment the dynamic library load path and python path respectively,
-    assuming that you choose to leave these entities where they were built and installed as per above commands and that you
+    The above makes and installs the shared libraries and Python interface in `/usr/local`.
+    To have these be used by Aqua, the following commands can be entered to augment the dynamic
+    library load path and python path respectively, assuming that you choose to leave these
+    entities where they were built and installed as per above commands and that you
     are running Python 3.6:
 
     .. code:: sh
@@ -924,8 +925,9 @@ in the ``nlopt`` subfolder of the ``optimizers`` folder.
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib64
         export PYTHONPATH=/usr/local/lib/python3.6/site-packages:${PYTHONPATH}
 
-    The two ``export`` commands above can be pasted into the ``.bash_profile`` file in the user's home directory for
-    automatic execution.  Now you can run Aqua and these optimizers should be available for you to use.
+    The two ``export`` commands above can be pasted into the ``.bash_profile`` file in the user's
+    home directory for automatic execution.  Now you can run Aqua and these optimizers should be
+    available for you to use.
 
 .. topic:: The ``max_evals`` Parameter
 
@@ -943,22 +945,24 @@ in the ``nlopt`` subfolder of the ``optimizers`` folder.
 
 Currently, Aqua supplies the following global optimizers from NLOpt:
 
-- :ref:`Controller Random Search (CRS) with Local Mutation`
-- :ref:`DIviding RECTangles algorithm - Locally based (DIRECT-L)`
-- :ref:`DIviding RECTangles algorithm - Locally based - RANDomized (DIRECT-L-RAND)`
-- :ref:`Evolutionary Strategy algorithm with CaucHy distribution (ESCH)`
-- :ref:`Improved Stochastic Ranking Evolution Strategy (ISRES)`
+- :ref:`crs`
+- :ref:`direct-l`
+- :ref:`direct-l-rand)`
+- :ref:`esch`
+- :ref:`isres`
 
 .. _crs:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Controller Random Search (CRS) with Local Mutation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`CRS with local mutation <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#controlled-random-search-crs-with-local-mutation>`__
+`CRS with local mutation
+<http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms\
+/#controlled-random-search-crs-with-local-mutation>`__
 is part of the family of the CRS optimizers.
 The CRS optimizers start with a random population of points, and randomly evolve these points by
 heuristic rules. In the case of CRS with local mutation, the evolution is a randomized version of
-the :ref:`Nelder-Mead` local optimizer.
+the :ref:`nelder-mead` local optimizer.
 
 .. topic:: Declarative Name
 
@@ -973,8 +977,8 @@ DIviding RECTangles algorithm - Locally based (DIRECT-L)
 
 DIviding RECTangles (DIRECT) is a deterministic-search algorithms based on systematic division of
 the search domain into increasingly smaller hyperrectangles.
-The `DIRECT-L <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#direct-and-direct-l>`__ version
-is a variant of DIRECT that makes the algorithm more biased towards local search,
+The `DIRECT-L <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#direct-and-direct-l>`__
+version is a variant of DIRECT that makes the algorithm more biased towards local search,
 so that it is more efficient for functions with few local minima.
 
 .. topic:: Declarative Name
@@ -988,8 +992,8 @@ so that it is more efficient for functions with few local minima.
 DIviding RECTangles algorithm - Locally based - RANDomized (DIRECT-L-RAND)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`DIRECT-L-RAND <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#direct-and-direct-l>`__ is a variant of
-:ref:`DIviding RECTangles algorithm - Locally based (DIRECT-L)`
+`DIRECT-L-RAND <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#direct-and-direct-l>`__
+is a variant of :ref:`direct-l`
 that uses some randomization to help decide which dimension to halve next in the case of near-ties.
 
 .. topic:: Declarative Name
@@ -1018,13 +1022,15 @@ Specifically, it does not support nonlinear constraints.
 Improved Stochastic Ranking Evolution Strategy (ISRES)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`ISRES <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#isres-improved-stochastic-ranking-evolution-strategy>`__
+`ISRES <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms\
+/#isres-improved-stochastic-ranking-evolution-strategy>`__
 is an algorithm for nonlinearly-constrained global optimization.
 It has heuristics to escape local optima, even though convergence to a global optima is not
 guaranteed. The evolution strategy is based on a combination of a mutation rule and differential
 variation. The fitness ranking is simply via the objective function for problems without nonlinear
 constraints. When nonlinear constraints are included, the
-`stochastic ranking proposed by Runarsson and Yao <https://notendur.hi.is/^tpr/software/sres/Tec311r.pdf>`__
+`stochastic ranking proposed by Runarsson and Yao
+<https://notendur.hi.is/^tpr/software/sres/Tec311r.pdf>`__
 is employed. This method supports arbitrary nonlinear inequality and equality constraints, in
 addition to the bound constraints.
 

--- a/docs/aqua/reciprocals.rst
+++ b/docs/aqua/reciprocals.rst
@@ -94,7 +94,7 @@ parameters. The following parameters are exposed:
 
       evo_time : float
 
-  This parameter scales the Eigenvalues in the :ref:`qpe_components` onto the range (0,1]
+  This parameter scales the Eigenvalues in the qpe component onto the range (0,1]
   ( (-0.5,0.5] for negativ EV ). If the Partial Table Look Up is used together with the QPE, the
   scale parameter can be estimated if the minimum EV and the evolution time are passed as
   parameters. The default is ``None``.
@@ -164,7 +164,7 @@ eigenvalues are enabled, the minimum value is ``4 ``The default is ``0``.
 
      evo_time : float
 
-  This parameter scales the Eigenvalues in the :ref:`qpe_components` onto the range (0,1]
+  This parameter scales the Eigenvalues in the qpe component onto the range (0,1]
   ( (-0.5,0.5] for negative EV ). If the Partial Table Look Up is used together with the QPE, the
   scale parameter can be estimated if the minimum EV and the evolution time are passed as
   parameters. The default is ``None``.

--- a/docs/aqua/uncertainty_problems.rst
+++ b/docs/aqua/uncertainty_problems.rst
@@ -16,7 +16,7 @@ speed-up. Thus, millions of classical samples could be replaced by a few thousan
 
 *Amplitude estimation* is a derivative of *quantum phase estimation* applied to a particular
 operator :math:`A`. :math:`A` is assumed to operate on (n+1) qubits (+ possible ancillas) where
-the n qubits represent the uncertainty (random distribution :ref:`random_distribution`) and the
+the n qubits represent the uncertainty (random distribution :ref:`random_distributions`) and the
 last qubit is used to represent the (normalized) objective value as its amplitude.
 In other words, :math:`A` is constructed such that the probability of measuring a '1' in the
 objective qubit is equal to the value of interest. An implementation of an uncertainty problem is
@@ -49,20 +49,25 @@ European Call Option
 
 .. topic:: Expected Value
 
-    Suppose a European call option with strike price :math:`K` and an underlying asset whose spot price at maturity :math:`S_T`
-    follows a given random distribution.
+    Suppose a European call option with strike price :math:`K` and an underlying asset whose spot
+    price at maturity :math:`S_T` follows a given random distribution.
     The corresponding payoff function is defined as :math:`\max \{ S - K, 0 \}`.
 
-    The *European call option - expected value* uncertainty problem takes the following input parameters:
+    The *European call option - expected value* uncertainty problem takes the
+    following input parameters:
 
-    - univariate random distribution for spot price (:ref:`random_distribution`)
+    - univariate random distribution for spot price (:ref:`random_distributions`)
     - strike price :math:`K`
-    - approximation scaling parameter :math:`c_{approx}` which specifies how well the objective function is approximated (needs to be synced with the number of evaluation qubits in amplitude estimation). For more details on the approximation, see https://arxiv.org/abs/1806.06893.
+    - approximation scaling parameter :math:`c_{approx}` which specifies how well the
+      objective function is approximated (needs to be synced with the number of evaluation
+      qubits in amplitude estimation). For more details on the approximation,
+      see https://arxiv.org/abs/1806.06893.
 
     .. code:: python
 
         # construct circuit factory for random distribution
-        uncertainty_model = LogNormalDistribution(num_uncertainty_qubits, mu=mu, sigma=sigma, low=low, high=high)
+        uncertainty_model = LogNormalDistribution(num_uncertainty_qubits, mu=mu,
+                                                  sigma=sigma, low=low, high=high)
 
         # set the strike price (should be within the low and the high value of the uncertainty)
         strike_price = 2
@@ -79,12 +84,13 @@ European Call Option
 
 .. topic:: Delta
 
-    The $\Delta$, of an option is defines as the derivative of the expected payfoff (respectively the price) with respect to the spot price.
+    The $\Delta$, of an option is defines as the derivative of the expected payfoff
+    (respectively the price) with respect to the spot price.
     For an European call option it can be defined as :math:`\Delta = P\left[ S_T \geq K \right]`.
 
     The *European call option - Delta* uncertainty problem takes the following input parameters:
 
-    - univariate random distribution for spot price (:ref:`random_distribution`)
+    - univariate random distribution for spot price (:ref:`random_distributions`)
     - the strike price :math:`K`
 
     .. code:: python
@@ -102,7 +108,8 @@ Fixed-Income Asset Pricing
 
 .. topic:: Expected Value
 
-    Here, we seek to price a fixed-income asset knowing the distributions describing the relevant interest rates.
+    Here, we seek to price a fixed-income asset knowing the distributions describing the
+    relevant interest rates.
     The cash flows :math:`c_t` of the asset and the dates at which they occur are known.
     The total value :math:`V` of the asset is thus the expectation value of:
 
@@ -110,25 +117,32 @@ Fixed-Income Asset Pricing
 
         V = \sum_{t=1}^T \frac{c_t}{(1+r_t)^t}
 
-    Each cash flow is treated as a zero coupon bond with a corresponding interest rate :math:`r_t` that depends on its maturity.
-    The user must specify the distribution modelling the uncertainty in each :math:`r_t` (possibly correlated)
+    Each cash flow is treated as a zero coupon bond with a corresponding interest rate :math:`r_t`
+    that depends on its maturity. The user must specify the distribution modelling the uncertainty
+    in each :math:`r_t` (possibly correlated)
     as well as the number of qubits he wishes to use to sample each distribution.
-    In this example we expand the value of the asset to first order in the interest rates :math:`r_t`.
+    In this example we expand the value of the asset to first order in the
+    interest rates :math:`r_t`.
     This corresponds to studying the asset in terms of its duration.
 
     The *Fixed-Income - Expected Value* uncertainty problem takes the following parameters:
 
     - multivariate random distribution: :math:`u`
-    - affine map from the random distribution to interest rates (e.g. from a principal component analysis): :math:`A`, :math:`b`
+    - affine map from the random distribution to interest rates (e.g. from a principal component
+      analysis): :math:`A`, :math:`b`
     - cash flow: :math:`c`
-    - approximation scaling parameter :math:`c_{approx}` which specifies how well the objective function is approximated (needs to be synced with the number of evaluation qubits in amplitude estimation). For more details on the approximation, see https://arxiv.org/abs/1806.06893.
+    - approximation scaling parameter :math:`c_{approx}` which specifies how well the objective
+      function is approximated (needs to be synced with the number of evaluation qubits in
+      amplitude estimation). For more details on the approximation,
+      see https://arxiv.org/abs/1806.06893.
 
     .. code:: python
 
         # construct corresponding distribution
         u = MultivariateNormalDistribution(num_qubits, low, high, mu, sigma)
 
-        # can be used in case a principal component analysis has been done to derive the random distribution,
+        # can be used in case a principal component analysis
+        # has been done to derive the random distribution,
         # ignored in this example
         A = np.eye(2)
         b = np.zeros(2)

--- a/docs/aqua/variational_forms.rst
+++ b/docs/aqua/variational_forms.rst
@@ -250,7 +250,7 @@ reduced to one Ry gate and one Rz gate with the summed rotation angles.
 
 The parameters of RyRz can be configured after selecting ``RYRZ`` as the value of the ``name``
 field in the
-``variational_form`` section of the Aqua :ref:`input-file`.  These parameters are ``depth``,
+``variational_form`` section of the Aqua :ref:`aqua-input-file`.  These parameters are ``depth``,
 ``entanglement``, ``entangler_map``, and ``skip_unentangled_qubits`` --- the same
 as those of :ref:`Ry`.
 
@@ -453,19 +453,19 @@ The following parameters allow a specific form to be configured:
 
 .. note::
 
-    When the ``auto_substitutions`` flag in the ``problem`` section of the Aqua Chemistry
-    :ref:`aqua-chemistry-input-file`
+    When the ``auto_substitutions`` flag in the ``problem`` section of the Qiskit Chemistry
+    :ref:`qiskit-chemistry-input-file`
     is set to ``True``, which is the default, the values of parameters
-    ``num_particles`` and ``num_orbitals`` are automatically computed by Aqua Chemistry
+    ``num_particles`` and ``num_orbitals`` are automatically computed by Qiskit Chemistry
     when ``UCCSD`` is selected as the value of the ``name`` parameter in the ``variational_forms``
     section. As such, their configuration is disabled; the user will not be required, or even
     allowed, to assign values to these two parameters.  This is also reflected in the
-    :ref:`aqua-chemistry-gui`, where these parameters will be grayed out and uneditable as long
+    :ref:`qiskit-chemistry-gui`, where these parameters will be grayed out and uneditable as long
     as ``auto_substitutions`` is set to ``True`` in the ``problem`` section.
-    Furthermore, Aqua Chemistry automatically sets
+    Furthermore, Qiskit Chemistry automatically sets
     parameters ``qubit_mapping`` and ``two_qubit_reduction`` in section ``variational_form`` when
     ``UCCSD`` is selected as the value of the ``name``
-    parameter.  Specifically, Aqua Chemistry sets ``qubit_mapping`` and ``two_qubit_reduction``
+    parameter.  Specifically, Qiskit Chemistry sets ``qubit_mapping`` and ``two_qubit_reduction``
     to the values the user assigned to them in the ``operator`` section
     of the input file in order to enforce parameter/value matching across these different
     sections.  As a result, the user will only have to configure ``qubit_mapping``
@@ -509,7 +509,7 @@ It was designed principally to be a particle-preserving variational form for
 The parameters of SwapRz can be configured after selecting ``SWAPRZ`` as the value of the ``name``
 field in the
 ``variational_form`` section of the Aqua
-:ref:`aqua-input file`.  These parameters are ``depth``. ``entanglement``, ``entangler_map``,
+:ref:`aqua-input-file`.  These parameters are ``depth``. ``entanglement``, ``entangler_map``,
 and ``skip_unentangled_qubits`` --- the same as those of :ref:`Ry`.
 
 Based on the notation introduced above for the entangler map associated with a variational form,


### PR DESCRIPTION
Fixed external tutorials link as well as multiple internal links.
Changed formatting of circuit collection so as refs get recognized and add lists as overview/quick jumps to the individual parts

