### PR TITLE
Handle missing qi modules

### DIFF
--- a/test/benchmarks/state_tomography.py
+++ b/test/benchmarks/state_tomography.py
@@ -24,7 +24,10 @@ try:
 except ImportError:
     NO_TOMO = True
 from qiskit.quantum_info import state_fidelity
-from qiskit.tools.qi.qi import random_unitary_matrix, purity
+try:
+    from qiskit.tools.qi.qi import random_unitary_matrix, purity
+except ImportError:
+    NO_TOMO = True
 
 
 class StateTomographyBench:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit/qiskit-terra#2761 removed some more of the deprecated qi modules
from terra that the state tomography benchmarks were previously relying
on. While we've been skipping these benchmarks since the tomography
module was removed from terra this caused an import error to be raised
when importing the test. To avoid the import error breaking asv runs until
we rewrite the benchmark to use ignis this commit handles an import
error and treats it as a skip condition.

### Details and comments