### PR TITLE
Fix small typo with versions in install documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -86,7 +86,7 @@ packages in your virtual environment.
 
 .. note::
 
-  When upgrading from Qiskit < 0.6 to the latest version, uninstall the old
+  When upgrading from Qiskit < 0.7 to the latest version, uninstall the old
   version of Qiskit with ``pip uninstall qiskit`` and then install the latest version.
 
 There are optional dependencies that are required to use all the visualization


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a small typo in the installation documentation about
when you need to manually upgrade from an old qiskit version. The manual
step is needed when upgrading from a version older than 0.7 to a version
newer than 0.7. This is because 0.7 is the release where the qiskit
package was split into terra and aer. The docs incorrectly had < 0.6
when it should have been < 0.7 (or <=0.6.1), which is what is listed in
the readme.

### Details and comments