### PR TITLE
Add a note to the install from source about perils of namespaces

### DIFF
--- a/docs/contributing_to_qiskit.rst
+++ b/docs/contributing_to_qiskit.rst
@@ -124,6 +124,16 @@ pip version is behind the source versions:
 To work with several components and elements simultaneously, use the following
 steps for each element.
 
+.. note::
+
+Due to the use of namespace packaging in python care must be taken in how you
+install packages. If you're planning to install any element from source do not
+use the qiskit meta-package. Also follow this guide and use a separate virtual
+environment for development. If you do choose to mix an existing installation
+with your development refer to:
+https://github.com/pypa/sample-namespace-packages/blob/master/table.md
+for the set of of combinations for installation methods that work together.
+
 The following steps show the installation process for Ignis.
 
 1. Clone the Qiskit element repository.

--- a/docs/contributing_to_qiskit.rst
+++ b/docs/contributing_to_qiskit.rst
@@ -126,13 +126,13 @@ steps for each element.
 
 .. note::
 
-Due to the use of namespace packaging in python care must be taken in how you
-install packages. If you're planning to install any element from source do not
-use the qiskit meta-package. Also follow this guide and use a separate virtual
-environment for development. If you do choose to mix an existing installation
-with your development refer to:
-https://github.com/pypa/sample-namespace-packages/blob/master/table.md
-for the set of of combinations for installation methods that work together.
+   Due to the use of namespace packaging in Python, care must be taken in how you
+   install packages. If you're planning to install any element from source do not
+   use the ``qiskit`` meta-package. Also follow this guide and use a separate virtual
+   environment for development. If you do choose to mix an existing installation
+   with your development refer to:
+   https://github.com/pypa/sample-namespace-packages/blob/master/table.md
+   for the set of of combinations for installation methods that work together.
 
 The following steps show the installation process for Ignis.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since the qiskit package uses namespace packaging there are a lot of
potential pitfalls when trying to mix and match element installations.
Due to the limitations in python packaging and the lack of any real
standardization there are many possible permutations. This commit
attempts to assist users by adding a note to the documentation
explaining the situation in a bit more detail. It also advises always
using a virtual environment so users can simply start from scratch when
things inevitably stop working.

### Details and comments