### PR TITLE
Fix QuantumRegister naming/assignments in code snippet

### DIFF
--- a/docs/terra/custom_gates.rst
+++ b/docs/terra/custom_gates.rst
@@ -57,7 +57,7 @@ location.
   # Convert to a gate and stick it into an arbitrary place in the bigger circuit
   sub_inst = sub_circ.to_instruction()
 
-  ​qr = QuantumRegister(3, 'q')
+  qr = QuantumRegister(3, 'q')
   circ = QuantumCircuit(qr)
   circ.h(qr[0])
   circ.cx(qr[0], qr[1])

--- a/docs/terra/custom_gates.rst
+++ b/docs/terra/custom_gates.rst
@@ -57,12 +57,12 @@ location.
   # Convert to a gate and stick it into an arbitrary place in the bigger circuit
   sub_inst = sub_circ.to_instruction()
 
-  ​q = QuantumRegister(3, 'q')
-  circ = QuantumCircuit(q)
+  ​qr = QuantumRegister(3, 'q')
+  circ = QuantumCircuit(qr)
   circ.h(qr[0])
   circ.cx(qr[0], qr[1])
   circ.cx(qr[1], qr[2])
-  circ.append(sub_inst, [q[1], q[2]])
+  circ.append(sub_inst, [qr[1], qr[2]])
 
   circ.draw(output='mpl')
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The code snippet under Composite Gates would give an error if run. The `QuantumRegister` that was being created was not named the same as the one that was being used to apply gates. This unifies all mentions of the `QuantumRegister` to be named `qr`