### PR TITLE
Fix install instructions and links

### DIFF
--- a/docs/aqua/ai/qiskit_ai.rst
+++ b/docs/aqua/ai/qiskit_ai.rst
@@ -83,7 +83,10 @@ and algorithm components, such as new :ref:`oracles` for the :ref:`grover` algor
 Examples
 --------
 
-The ``qiskit/artificial_intelligence`` and ``community/artificial_intelligence`` folders of the
-`Qiskit Tutorials GitHub Repository <https://github.com/Qiskit/qiskit-tutorials>`__
+The ``qiskit/advanced/aqua/artificial_intelligence`` folder of
+`Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ and
+``artificial_intelligence`` folder of the
+`Qiskit Tutorials Community <https://github.com/Qiskit/qiskit-tutorials-community>`__
+GitHub Repositories
 contain `Jupyter Notebooks <http://jupyter.org/>`__ and sample input data files
 explaining how to use Qiskit AI.

--- a/docs/aqua/algorithms.rst
+++ b/docs/aqua/algorithms.rst
@@ -124,8 +124,8 @@ Additionally, VQE can be configured with the following parameters:
    molecule, it is likely that using the previous computed optimal solution as the starting
    initial point for the next interatomic distance is going to reduce the number of iterations
    necessary for the variational algorithm to converge.  Aqua provides an
-   `initial point tutorial <https://github.com/Qiskit/qiskit-tutorials/blob/master
-   /community/chemistry/h2_vqe_initial_point.ipynb>`__ detailing this use case.
+   `initial point tutorial <https://github.com/Qiskit/qiskit-tutorials-community/blob/master
+   /chemistry/h2_vqe_initial_point.ipynb>`__ detailing this use case.
 
    The length of the ``initial_point`` list value must match the number of the parameters
    expected by the variational form being used. If the user does not supply a preferred

--- a/docs/aqua/chemistry/qiskit_chemistry.rst
+++ b/docs/aqua/chemistry/qiskit_chemistry.rst
@@ -50,7 +50,7 @@ experiments on a quantum machine by using either the
 tools, or the :ref:`qiskit-chemistry-programmable-interface`. Either option
 enforces schema-based configuration correctness.
 
-.. topic:: Contributing to Qiskit Chemistry
+.. topic:: Contributing to Qiskit Chemistry in Qiskit Aqua
 
     Instead of just *accessing* Qiskit Chemistry as a tool to experiment with chemistry problems
     on a quantum machine, a user may decide to *contribute* to Qiskit Chemistry by
@@ -62,9 +62,7 @@ enforces schema-based configuration correctness.
     Qiskit Chemistry utilizes a similar framework for drivers and the core computation
     performed at the input-translation layer.
 
-    If you would like to contribute to Qiskit Chemistry, please follow the
-    Qiskit Chemistry `contribution
-    guidelines <https://github.com/Qiskit/qiskit-chemistry/blob/master/.github/CONTRIBUTING.rst>`__.
+    If you would like to contribute please read :doc:`/contributing_to_qiskit`
 
 .. toctree::
    :maxdepth: 3

--- a/docs/aqua/chemistry/qiskit_chemistry_execution.rst
+++ b/docs/aqua/chemistry/qiskit_chemistry_execution.rst
@@ -149,8 +149,8 @@ extracts from that execution the molecular structural data necessary to form
 the input to one of the Aqua quantum algorithms, and finally invokes that algorithm
 to build, compile and execute a circuit modeling the experiment on top of a quantum
 machine.  An example of this is available in the `PySCF Driver tutorial
-<https://github.com/Qiskit/qiskit-tutorials/blob/master\
-/community/chemistry/PySCFChemistryDriver.ipynb>`__.
+<https://github.com/Qiskit/qiskit-tutorials-community/blob/master/
+chemistry/PySCFChemistryDriver.ipynb>`__.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Declarative Programming Interface
@@ -267,9 +267,9 @@ classical algorithm.  A comparison with the :ref:`Hartree-Fock` energy is also o
 
 More complex examples include
 `plotting the dissociation curve
-<https://github.com/Qiskit/qiskit-tutorials/blob/master/community/chemistry/lih_dissoc.ipynb>`__
+<https://github.com/Qiskit/qiskit-tutorials-community/blob/master/chemistry/lih_dissoc.ipynb>`__
 or `comparing results obtained via different algorithms
-<https://github.com/Qiskit/qiskit-tutorials/blob/master/community/chemistry/lih_uccsd.ipynb>`__
+<https://github.com/Qiskit/qiskit-tutorials-community/blob/master/chemistry/lih_uccsd.ipynb>`__
 
 ^^^^^^^^^^^^^^^^^
 Result Dictionary
@@ -316,7 +316,7 @@ supplied.
 
 Several sample input files can be found in the `chemistry folder of
 the Qiskit Tutorials GitHub repository
-<https://github.com/Qiskit/qiskit-tutorials/tree/master/community/chemistry/input_files>`__
+<https://github.com/Qiskit/qiskit-tutorials-community/blob/master/chemistry/input_files>`__
 
 The Qiskit Chemistry input file is a logical extension of the Aqua :ref:`aqua-input-file`
 and adds sections ``name``, ``driver`` and ``operator`` to define the chemistry part of the

--- a/docs/aqua/chemistry/qiskit_chemistry_installation.rst
+++ b/docs/aqua/chemistry/qiskit_chemistry_installation.rst
@@ -4,58 +4,19 @@
 Installation and Setup
 ======================
 
-------------
-Dependencies
-------------
+Qiskit Chemistry is automatically installed during the Qiskit Aqua installation as it forms
+part of Qiskit Aqua. Please see :ref:`aqua-installation` for detailed instructions.
 
-Qiskit Chemistry is built upon Aqua.
-Like Aqua, at least `Python 3.5 or
-later <https://www.python.org/downloads/>`__ is needed to use Qiskit
-Qiskit Chemistry. In addition, `Jupyter
-Notebook <https://jupyter.readthedocs.io/en/latest/install.html>`__ is
-recommended for interacting with the tutorials. For this reason we
-recommend installing the `Anaconda
-3 <https://www.continuum.io/downloads>`__ Python distribution, as it
-comes with all of these dependencies pre-installed.
-
-.. _qiskit-chemistry-code-installation:
-
------------------
-Code Installation
------------------
-
-We encourage you to install Qiskit Chemistry via the `pip <https://pypi.org/project/pip/>`__
-package management system:
-
-.. code:: sh
-
-   pip install qiskit-chemistry
-
-pip will handle all dependencies automatically (including the dependencies on Aqua and
-Qiskit Core). and you will always install the latest (and well-tested) release version.
-
-If your intention is not so much to access Qiskit Chemistry
-as a tool to perform chemistry computations on a quantum machine, but rather to extend Qiskit
-Chemistry with new research contributions --- such as new algorithms, algorithm components,
-input-translation operators or drivers --- then it is advisable to clone both the
-`Qiskit Chemistry <https://github.com/Qiskit/qiskit-chemistry>`__ and
-`Aqua <https://github.com/Qiskit/qiskit-aqua>`__ Git repositories in order
-to have easier access to the source code of the various components.
-
-.. note::
-
-    We recommend using Python virtual environments to improve your experience.
-
-Jupyter Notebooks and input files for Qiskit Chemistry are included as part of the
-`Qiskit Tutorials <https://nbviewer.jupyter.org/github/Qiskit/qiskit-tutorials/blob/master/index.ipynb>`__.
+Qiskit Chemistry does however require the installation of a chemistry driver
+in order to use it fully, please see the next section below.
 
 ---------------------------------
 Installation of Chemistry Drivers
 ---------------------------------
 
-To run chemistry experiments on various molecules, you will also need to install one of the
-supported classical computational chemistry programs, or *drivers*, interfaced by Qiskit Chemistry.
-Currently, Qiskit Chemistry comes with built-in interfaces for four drivers:
+To run chemistry experiments on various molecules, you will also need to install at least one of
+the supported classical computational chemistry programs, or *drivers*, interfaced by
+Qiskit Chemistry. Currently, Qiskit Chemistry comes with built-in interfaces for four drivers:
 
 1. `Gaussian™ 16 <http://gaussian.com/gaussian16/>`__, a commercial chemistry program
 2. `PSI4 <http://www.psicode.org/>`__, an open-source chemistry program built on Python
@@ -63,11 +24,15 @@ Currently, Qiskit Chemistry comes with built-in interfaces for four drivers:
 4. `PyQuante <http://pyquante.sourceforge.net/>`__, a pure cross-platform open-source Python
    chemistry program
 
-While the logic to
-interface these drivers is supplied as part of the Qiskit Chemistry installation, the dependent
-chemistry programs need to be installed separately.  This can be done by following the
-instructions provided in Section ":ref:`drivers`". Supporting additional drivers in Qiskit
-Chemistry can be easily achieved by extending the ``BaseDriver`` interface.
+.. note::
+
+    For non-Windows platforms the PySCF driver is automatically installed as a dependency
+    of Qiskit Chemistry. You are free however to add additional driver(s) and use
+    the one(s) of your choosing.
+
+While the logic to interface these drivers is supplied as part of the Qiskit Chemistry
+installation, the dependent chemistry programs need to be installed separately.
+This can be done by following the instructions provided in Section ":ref:`drivers`".
 
 Even without installing any of the drivers above, it is still possible to run chemistry experiments
 by using a previously created Hierarchical Data Format 5 (HDF5) binary file. Such files are created
@@ -78,6 +43,11 @@ Qiskit Chemistry has :ref:`hdf5` as an additional driver --- in fact, the only b
 coming with Qiskit Chemistry.
 
 A few sample HDF5 files are provided as input files in the ``chemistry`` folder of the
-`Qiskit Tutorials \
-<https://github.com/Qiskit/qiskit-tutorials/tree/master/community/chemistry/input_files>`__
+`Qiskit Tutorials Community \
+<https://github.com/Qiskit/qiskit-tutorials-community/tree/master/chemistry/input_files>`__
 repository.
+
+Supporting additional drivers in Qiskit Chemistry can be easily achieved by extending
+the ``BaseDriver`` interface. See "Extending Qiskit Chemistry with Support for New Drivers"
+in :ref:`drivers` section for more detail.
+

--- a/docs/aqua/chemistry/qiskit_chemistry_license.rst
+++ b/docs/aqua/chemistry/qiskit_chemistry_license.rst
@@ -9,7 +9,6 @@ license <https://www.apache.org/licenses/LICENSE-2.0>`__.
 Some code supplied by Qiskit Chemistry for interfacing
 to external chemistry :ref:`drivers` has additional licensing:
 
--  The :ref:`gaussian-16`
-   driver
-   contains work licensed under the `Gaussian Open-Source Public
-   License <https://github.com/Qiskit/qiskit-chemistry/blob/master/qiskit_chemistry/drivers/gaussiand/gauopen/LICENSE.txt>`__.
+-  The :ref:`gaussian-16` driver
+   contains work licensed under the `Gaussian Open-Source Public License <https://github.com/
+   Qiskit/qiskit-aqua/blob/master/qiskit/chemistry/drivers/gaussiand/gauopen/LICENSE.txt>`__.

--- a/docs/aqua/chemistry/release_history.rst
+++ b/docs/aqua/chemistry/release_history.rst
@@ -144,11 +144,13 @@ compilation of the circuits. For the full set of options, please refer
 to the documentation of the Aqua ``QuantumInstance`` API.
 
 Numerous new Qiskit Chemistry notebooks in the
-`qiskit/aqua <https://github.com/Qiskit/qiskit-tutorials/tree/master/qiskit/aqua>`__
+`qiskit/advanced/aqua/chemistry
+<https://github.com/Qiskit/qiskit-tutorials/tree/master/qiskit/advanced/aqua/chemistry>`__
+folder of the `Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ repository
 and
-`community/aqua <https://github.com/Qiskit/qiskit-tutorials/tree/master/community/aqua>`__
-folders of the `Qiskit
-Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ repository
+`chemistry <https://github.com/Qiskit/qiskit-tutorials-community/tree/master/chemistry>`__
+folder of the `Qiskit
+Tutorials Community <https://github.com/Qiskit/qiskit-tutorials-community>`__ repository
 illustrate how to conduct a quantum-computing experiment
 programmatically using the new Aqua APIs.
 

--- a/docs/aqua/finance/qiskit_finance.rst
+++ b/docs/aqua/finance/qiskit_finance.rst
@@ -25,7 +25,8 @@ Qiskit Finance Problems
 Qiskit Finance can already be used to experiment with financial analysis and optimization
 problems, such as risk analysis and
 `portfolio optimization
-<https://github.com/Qiskit/aqua-tutorials/blob/master/finance/portfolio_optimization.ipynb>`__.
+<https://github.com/Qiskit/qiskit-tutorials/blob/master/qiskit/advanced/aqua/
+finance/optimization/portfolio_optimization.ipynb>`__.
 
 ------------------------------
 Contributing to Qiskit Finance
@@ -46,8 +47,10 @@ for Support Vector Machine (SVM) algorithms, such as :ref:`vqc` and
 Examples
 --------
 
-The ``qiskit/finance`` and ``community/finance`` folders of the
-`Qiskit Tutorials GitHub Repository <https://github.com/Qiskit/qiskit-tutorials>`__
+The ``qiskit/advanced/aqua/finance`` folder of
+`Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ and
+``finance`` folder of the
+`Qiskit Tutorials Community <https://github.com/Qiskit/qiskit-tutorials-community>`__
+GitHub Repositories
 contain `Jupyter Notebooks <http://jupyter.org/>`__ and sample input data files
 explaining how to use Qiskit Finance.
-

--- a/docs/aqua/installation.rst
+++ b/docs/aqua/installation.rst
@@ -7,52 +7,48 @@ Installing Qiskit Aqua
 Aqua can be used as a tool to execute `quantum algorithms <#quantum-algorithms.html>`__.
 With the appropriate input, a quantum algorithm will run on top of the underlying
 `Terra <https://qiskit.org/terra>`__
-platform, which will generate, compile and execute a circuit modeling the input problem.
+platform, which will compile and execute circuits from Aqua modeling the input problem.
 Aqua can also be used as the foundation for domain-specific applications, such as
-:ref:`aqua-chemistry`, :ref:`aqua-ai` and :ref:`aqua-optimization`.
-This section describes how to install and setup Aqua based on the user's goals.
-
-------------
-Dependencies
-------------
-
-At least `Python 3.5 or
-later <https://www.python.org/downloads/>`__ is needed to use
-Aqua. In addition, `Jupyter
-Notebook <https://jupyter.readthedocs.io/en/latest/install.html>`__ is
-recommended for interacting with the tutorials. For this reason, we
-recommend installing the `Anaconda
-3 <https://www.anaconda.com/download/>`__ Python distribution, as it
-comes with all of these dependencies pre-installed.
-
-.. seealso::
-    Since Aqua is built upon `Terra <https://qiskit.org/terra>`__,
-    you are encouraged to look over the
-    `Terra
-    installation and setup instructions <https://qiskit.org/documentation/install.html>`__.
+:ref:`aqua-chemistry`, :ref:`aqua-finance`, :ref:`aqua-ai` and :ref:`aqua-optimization`.
+This section describes how to install and setup Aqua.
 
 ------------
 Installation
 ------------
 
-The best way to install Aqua when the goal is to use it as a tool or as a library
-of quantum algorithms is via the `pip <https://pip.pypa.io/en/stable/>`__  package management system:
+The best way to install Aqua, when the goal is to use it as a tool or as a library
+of quantum algorithms, is via the `pip <https://pip.pypa.io/en/stable/>`__  package management system.
+Qiskit provides a meta-package that installs the set of Qiskit Elements, including Qiskit Aqua and its
+domain code for Chemistry, Finance, AI and Optimization.
+
+Please see :doc:`/install` for detailed installation instructions
+
+---------------------------------
+Installing Qiskit-Aqua Standalone
+---------------------------------
+
+While we recommend following the prior installation section above, it is possible
+to install Qiskit Aqua directly, which will also install its dependencies such
+as Qiskit-Terra and Qiskit-Ignis, but it will not install other optional aspects such as qiskit-aer
+and qiskit-ibmq-provider.
 
 .. code:: sh
 
-    pip install qiskit_aqua
+    pip install qiskit-aqua
 
 pip will handle all dependencies automatically and you will always
 install the latest (and well-tested) release version.
+
+----------------------
+Installing from Source
+----------------------
 
 A different class of users --- namely, quantum researchers and developers --- might be more
 interested in exploring the source code of Aqua and :ref:`aqua-extending` by providing
 new components, such as :ref:`quantum-algorithms`, :ref:`optimizers`, :ref:`variational-forms`,
 :ref:`iqfts`, :ref:`oracles` and :ref:`initial-states`.
-The best way to install Aqua when the goal is to extend its capabilities is by cloning
-the `Aqua repository <https://github.com/Qiskit/aqua>`__.
 
-.. note::
-
-    We recommend using `Python virtual environments <https://docs.python.org/3/tutorial/venv.html>`__
-    to cleanly separate Qiskit from other applications and improve your experience.
+If you want to explore the code more directly and experiment with it, and even contribute
+to the Qiskit community by developing and contributing code then you should work with
+clones of the master branches of the Qiskit repositories. For detailed instructions on how
+to do this see :ref:`Build Qiskit packages from source <install_install_from_source_label>`.

--- a/docs/aqua/installation.rst
+++ b/docs/aqua/installation.rst
@@ -17,9 +17,10 @@ Installation
 ------------
 
 The best way to install Aqua, when the goal is to use it as a tool or as a library
-of quantum algorithms, is via the `pip <https://pip.pypa.io/en/stable/>`__  package management system.
-Qiskit provides a meta-package that installs the set of Qiskit Elements, including Qiskit Aqua and its
-domain code for Chemistry, Finance, AI and Optimization.
+of quantum algorithms, is via the `pip <https://pip.pypa.io/en/stable/>`__
+package management system. Qiskit provides a meta-package that installs the set of
+Qiskit Elements, including Qiskit Aqua and its domain code for Chemistry, Finance, AI
+and Optimization.
 
 Please see :doc:`/install` for detailed installation instructions
 
@@ -29,8 +30,8 @@ Installing Qiskit-Aqua Standalone
 
 While we recommend following the prior installation section above, it is possible
 to install Qiskit Aqua directly, which will also install its dependencies such
-as Qiskit-Terra and Qiskit-Ignis, but it will not install other optional aspects such as qiskit-aer
-and qiskit-ibmq-provider.
+as Qiskit-Terra and Qiskit-Ignis, but it will not install other optional aspects such as
+qiskit-aer and qiskit-ibmq-provider.
 
 .. code:: sh
 

--- a/docs/aqua/iqfts.rst
+++ b/docs/aqua/iqfts.rst
@@ -11,7 +11,7 @@ and computing the discrete logarithm, and the :ref:`QPE` algorithm for
 estimating the eigenvalues of a unitary operator.
 A QFT can be performed efficiently on a quantum computer, with a particular
 decomposition into a product of simpler unitary matrices.
-`It has been shown <http://csis.pace.edu/ctappert/cs837-18spring/QC-textbook.pdf>`__ how,
+`It has been shown <http://csis.pace.edu/ctappert/cs837-19spring/QC-textbook.pdf>`__ how,
 using a simple decomposition,
 the discrete Fourier transform on :math:`2^n` amplitudes can be implemented as a
 quantum circuit consisting of only :math:`O(n^2)` Hadamard gates and controlled phase

--- a/docs/aqua/optimization/qiskit_optimization.rst
+++ b/docs/aqua/optimization/qiskit_optimization.rst
@@ -23,10 +23,18 @@ Qiskit Optimization Problems
 Qiskit Optimization can already be used to experiment with numerous well known optimization
 problems, such as:
 
-1. `Stable Set <https://github.com/Qiskit/qiskit-tutorials/blob/master/community/optimization/stable_set.ipynb>`__
-2. `Maximum Cut (Max-Cut) <https://github.com/Qiskit/qiskit-tutorials/blob/master/community/optimization/max_cut.ipynb>`__
-3. `Partition <https://github.com/Qiskit/qiskit-tutorials/blob/master/community/optimization/partition.ipynb>`__
-4. `3 Satisfiability (3-SAT) <https://github.com/Qiskit/qiskit-tutorials/blob/master/community/optimization/grover.ipynb>`__
+1. `Stable Set
+   <https://github.com/Qiskit/qiskit-tutorials-community/
+   blob/master/optimization/stable_set.ipynb>`__
+2. `Maximum Cut (Max-Cut)
+   <https://github.com/Qiskit/qiskit-tutorials-community/
+   blob/master/optimization/max_cut.ipynb>`__
+3. `Partition
+   <https://github.com/Qiskit/qiskit-tutorials-community/
+   blob/master/optimization/partition.ipynb>`__
+4. `3 Satisfiability (3-SAT)
+   <https://github.com/Qiskit/qiskit-tutorials-community/
+   blob/master/optimization/grover.ipynb>`__
 
 
 --------------------------------
@@ -69,8 +77,11 @@ for Support Vector Machine
 Examples
 --------
 
-The ``qiskit/optimization`` and ``community/optimization`` folders of the
-`Qiskit Tutorials GitHub Repository <https://github.com/Qiskit/qiskit-tutorials>`__
+The ``qiskit/advanced/aqua/optimization`` folder of
+`Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ and
+``optimization`` folder of the
+`Qiskit Tutorials Community <https://github.com/Qiskit/qiskit-tutorials-community>`__
+GitHub Repositories
 contain `Jupyter Notebooks <http://jupyter.org/>`__ and sample input data files
 explaining how to use Qiskit Optimization.
 

--- a/docs/aqua/optimizers.rst
+++ b/docs/aqua/optimizers.rst
@@ -957,7 +957,7 @@ Currently, Aqua supplies the following global optimizers from NLOpt:
 Controller Random Search (CRS) with Local Mutation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 `CRS with local mutation
-<http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms\
+<http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms
 /#controlled-random-search-crs-with-local-mutation>`__
 is part of the family of the CRS optimizers.
 The CRS optimizers start with a random population of points, and randomly evolve these points by
@@ -1022,7 +1022,7 @@ Specifically, it does not support nonlinear constraints.
 Improved Stochastic Ranking Evolution Strategy (ISRES)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`ISRES <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms\
+`ISRES <http://nlopt.readthedocs.io/en/latest/NLopt_Algorithms
 /#isres-improved-stochastic-ranking-evolution-strategy>`__
 is an algorithm for nonlinearly-constrained global optimization.
 It has heuristics to escape local optima, even though convergence to a global optima is not
@@ -1030,7 +1030,7 @@ guaranteed. The evolution strategy is based on a combination of a mutation rule 
 variation. The fitness ranking is simply via the objective function for problems without nonlinear
 constraints. When nonlinear constraints are included, the
 `stochastic ranking proposed by Runarsson and Yao
-<https://notendur.hi.is/^tpr/software/sres/Tec311r.pdf>`__
+<https://notendur.hi.is/tpr/software/sres/Tec311r.pdf>`__
 is employed. This method supports arbitrary nonlinear inequality and equality constraints, in
 addition to the bound constraints.
 

--- a/docs/aqua/oracles.rst
+++ b/docs/aqua/oracles.rst
@@ -95,11 +95,10 @@ clause.  Essentially, the code above corresponds to the following CNF:
 \land (x_1 \lor \lnot x_2 \lor \lnot x_3)
 \land (\lnot x_1 \lor x_2 \lor x_3)`.
 
-An example showing how to use the Grover algorithm on a DIMACS oracle
-to search for a satisfying assignment to an SAT problem encoded in DIMACS
-is available in the ``optimization`` folder of the
-`Qiskit Tutorials GitHub repository
-<https://github.com/Qiskit/qiskit-tutorials/tree/master/community/aqua>`__.
+This is an example showing how to
+`use the Grover algorithm
+<https://github.com/Qiskit/qiskit-tutorials-community/blob/master/optimization/grover.ipynb>`__
+to search for a satisfying assignment to an SAT problem encoded in DIMACS.
 
 Logic expressions, regardless of the input formats,
 are parsed and stored as Abstract Syntax Tree (AST) tuples,

--- a/docs/aqua/release_history.rst
+++ b/docs/aqua/release_history.rst
@@ -176,11 +176,11 @@ compilation of the circuits. For the full set of options, please refer
 to the documentation of the Aqua ``QuantumInstance`` API.
 
 Numerous new notebooks in the
-`qiskit/aqua <https://github.com/Qiskit/qiskit-tutorials/tree/master/qiskit/aqua>`__
-and
-`community/aqua <https://github.com/Qiskit/qiskit-tutorials/tree/master/community/aqua>`__
-folders of the `Qiskit
-Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ repository
+``qiskit/advanced/aqua/`` folder of
+`Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ and
+``aqua`` folder of the
+`Qiskit Tutorials Community <https://github.com/Qiskit/qiskit-tutorials-community>`__
+GitHub Repositories
 illustrate how to conduct a quantum-computing experiment
 programmatically using the new Aqua APIs.
 
@@ -323,8 +323,8 @@ delta, using univariate distributions) and *Fixed Income Asset Pricing*
 (expected value, using multivariate distributions). New Jupyter
 Notebooks illustrating the use of the Amplitude Estimation algorithm to
 deal with these new problems are available in the `Qiskit Finance
-tutorials
-repository <https://github.com/Qiskit/qiskit-tutorials/tree/master/qiskit/aqua/finance>`__.
+tutorials repository
+<https://github.com/Qiskit/qiskit-tutorials/tree/master/qiskit/advanced/aqua/finance>`__.
 
 ^^^^^^^^^
 Qiskit AI
@@ -361,4 +361,4 @@ partition <https://en.wikipedia.org/wiki/Graph_partition>`__. All this
 problems are solved with VQE. Jupyter Notebooks illustrating how to use
 a quantum computer to solve these problems are available in the `Qiskit
 community Optimization tutorials
-repository <https://github.com/Qiskit/qiskit-tutorials/tree/master/community/aqua/optimization>`__.
+repository <https://github.com/Qiskit/qiskit-tutorials-community/tree/master/optimization>`__.

--- a/docs/aqua/tutorials/aqua_tutorials.rst
+++ b/docs/aqua/tutorials/aqua_tutorials.rst
@@ -5,10 +5,13 @@ Aqua Tutorials
 **************
 
 A large number of tutorials illustrating how to use and extend Qiskit Aqua and its applications
-are available in the ``qiskit/aqua`` and ``community/aqua`` folders of the
-`Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ repository.
+are available in the ``qiskit/advanced/aqua`` folder of the
+`Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__ repository and ``aqua`` folder
+of the `Qiskit Tutorials Community <https://github.com/Qiskit/qiskit-tutorials-community>`__
+repository.
 
-In both ``qiskit`` and ``community`` folders you will also find Aqua domain examples in folders
+In ``qiskit/advanced/aqua`` folder and alongside ``aqua`` folder in community
+you will also find Aqua domain examples in folders
 ``artificial_intelligence``, ``chemistry``, ``finance`` and ``optimization``
 
 These tutorials are a set of code examples,
@@ -20,14 +23,16 @@ how to extend Aqua with new components.  This feature is particularly useful to
 quantum researchers who are interested in :ref:`aqua-extending` with new algorithmic
 components.
 
-The `Qiskit Tutorials repository <https://github.com/Qiskit/qiskit-tutorials>`__ is supposed to be
-installed via the ``git clone`` command.  This will allow the user to duplicate its code in a
+The `Qiskit Tutorials repository <https://github.com/Qiskit/qiskit-tutorials>`__ and
+`Qiskit Tutorials Community repository <https://github.com/Qiskit/qiskit-tutorials>`__
+may be copied locally using
+the ``git clone`` command.  This will allow the user to duplicate its code in a
 convenient location in the file system, where it will be easier to browse the examples and
 execute the Jupyter Notebooks we provide.
 
-A `Jupyter Notebook nbviewer of featured Qiskit tutorials
-<https://github.com/Qiskit/qiskit-tutorials/blob/master/qiskit/start_here.ipynb>`__
-and a `Jupyter Notebook nbviewer of Aqua community tutorials
-<https://github.com/Qiskit/qiskit-tutorials/blob/master/community/aqua/index.ipynb>`__
+A `Jupyter Notebook as a start to the featured Qiskit tutorials
+<https://github.com/Qiskit/qiskit-tutorials/blob/master/qiskit/1_start_here.ipynb>`__
+and a `Jupyter Notebook of Aqua community tutorials
+<https://github.com/Qiskit/qiskit-tutorials-community/blob/master/aqua/index.ipynb>`__
 allow for a quick and intuitive way to browse through the various sample programs presented.
 

--- a/docs/aqua/variational_forms.rst
+++ b/docs/aqua/variational_forms.rst
@@ -63,8 +63,8 @@ dynamically discovered at run time and made available for use by quantum variati
     using the previous computed optimal solution as the starting initial point for the
     next interatomic distance is going to reduce the number of iterations necessary for the
     variational algorithm to converge.  Aqua provides
-    `a tutorial detailing this use case <https://github.com/Qiskit/qiskit-tutorials/blob/\
-    master/community/chemistry/h2_vqe_initial_point.ipynb>`__.
+    `a tutorial detailing this use case <https://github.com/Qiskit/qiskit-tutorials-community/
+    blob/master/chemistry/h2_vqe_initial_point.ipynb>`__.
 
     :ref:`vqe` can, therefore, take an optional initial point from the user
     as the value of the ``initial_point`` parameter, specified as a list of ``float`` values.

--- a/docs/contributing_to_qiskit.rst
+++ b/docs/contributing_to_qiskit.rst
@@ -18,7 +18,6 @@ where you can find the individual projects that make up Qiskit, including
 * `Qiskit Aer <https://github.com/Qiskit/qiskit-aer>`__
 * `Qiskit Ignis <https://github.com/Qiskit/qiskit-ignis>`__
 * `Qiskit Aqua <https://github.com/Qiskit/qiskit-aqua>`__
-* `Qiskit Chemistry <https://github.com/Qiskit/qiskit-chemistry>`__
 * `Qiskit IBMQ Provider <https://github.com/Qiskit/qiskit-ibmq-provider>`__
 * `Qiskit Tutorials <https://github.com/Qiskit/qiskit-tutorials>`__
 * `Qiskit Documentation <https://github.com/Qiskit/qiskit/tree/master/docs>`__
@@ -110,7 +109,7 @@ require using the ``development`` version of the rest of the items as well.
 .. note::
 
   The Terra and Aer packages both require a compiler to build from source before
-  you can install. Ignis, Aqua, Qiskit Chemistry, and the IBM Q provider backend
+  you can install. Ignis, Aqua and the IBM Q provider backend
   do not require a compiler.
 
 Installing elements from source requires the following order of installation to
@@ -123,7 +122,6 @@ pip version is behind the source versions:
 #. qiskit-aer
 #. qiskit-ignis
 #. qiskit-aqua
-#. qiskit-chemistry
 
 To work with several components and elements simultaneously, use the following
 steps for each element.
@@ -632,42 +630,6 @@ Installing Aqua from Source
       pip install -r requirements-dev.txt
 
 4. Install aqua
-
-   .. code:: sh
-
-      pip install .
-
-If you want to install it in editable mode, meaning that code changes to the
-project don't require a reinstall to be applied you can do this with:
-
-.. code:: sh
-
-    pip install -e .
-
-Install Chemistry from Source
------------------------------
-
-1. Clone the qiskit-chemistry repository.
-
-   .. code:: sh
-
-     git clone https://github.com/Qiskit/qiskit-chemistry.git
-
-2. Cloning the repository creates a local directory called ``qiskit-chemistry``.
-
-   .. code:: sh
-
-      cd qiskit-chemistry
-
-3. If you want to run tests or linting checks, install the developer requirements.
-   This is not required to install or use the qiskit-chemistry package when
-   installing from source.
-
-   .. code:: sh
-
-      pip install -r requirements-dev.txt
-
-4. Install qiskit-chemistry
 
    .. code:: sh
 


### PR DESCRIPTION
1. Fix chemistry installation instructions following merge of qiskit-chemistry with qiskit-aqua repo
2. Fix broken links resulting from community split off from qiskit tutorials