### PR TITLE
Fix doc8 line length lint

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,10 +19,11 @@ quantum computers.
 
 Qiskit consists of four foundational elements:
 
-- :ref:`Qiskit Terra <Terra>`: Composing quantum programs at the level of circuits and pulses with the
-  code foundation.
+- :ref:`Qiskit Terra <Terra>`: Composing quantum programs at the level of circuits
+  and pulses with the code foundation.
 
-- :ref:`Qiskit Aer <Aer>`: Accelerating development via simulators, emulators, and debuggers
+- :ref:`Qiskit Aer <Aer>`: Accelerating development via simulators, emulators,
+  and debuggers
 
 - :ref:`Qiskit Ignis <Ignis>`: Addressing noise and errors
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 commands =
   pycodestyle test
   pylint -rn --rcfile={toxinidir}/.pylintrc test
-  doc8 --ignore D001 docs
+  doc8 docs
 
 [testenv:asv]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was only one line that was over the line length for the docs
linter. It's normally smart enough to know that links can't be broken
and doesn't count that against the line length (unless you have text on
the same line after a link). This commit removes the disabled check and
fixes the one spot it was complaining about line length.

### Details and comments