### PR TITLE
Fix doc version and release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 [UNRELEASED](https://github.com/Qiskit/qiskit/compare/0.12.0...HEAD)
 ====================================================================
 
-
-[0.12.0](https://github.com/Qiskit/qiskit/compare/0.11.2...0.12.0) - 2019-08-20
+[0.12.0](https://github.com/Qiskit/qiskit/compare/0.11.2...0.12.0) - 2019-08-22
 ===============================================================================
 
 Changed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ author = 'Qiskit Development Team'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.11.2'
+release = '0.12.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -757,6 +757,7 @@ Deprecation Notes
     * ``shift``
     * ``insert``
     * ``append``
+
   have equivalent methods available directly on the ``qiskit.pulse.Schedule``
   and ``qiskit.pulse.Instruction`` classes. Those methods should be used
   instead.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -519,18 +519,19 @@ Upgrade Notes
 - The following ``qiskit.dagcircuit.DAGCircuit`` methods had deprecated
   support for accepting a ``node_id`` as a parameter. This has been removed
   and now only ``DAGNode`` objects are accepted as input:
-  * ``successors()``
-  * ``predecessors()``
-  * ``ancestors()``
-  * ``descendants()``
-  * ``bfs_successors()``
-  * ``quantum_successors()``
-  * ``remove_op_node()``
-  * ``remove_ancestors_of()``
-  * ``remove_descendants_of()``
-  * ``remove_nonancestors_of()``
-  * ``remove_nondescendants_of()``
-  * ``substitute_node_with_dag()``
+
+    * ``successors()``
+    * ``predecessors()``
+    * ``ancestors()``
+    * ``descendants()``
+    * ``bfs_successors()``
+    * ``quantum_successors()``
+    * ``remove_op_node()``
+    * ``remove_ancestors_of()``
+    * ``remove_descendants_of()``
+    * ``remove_nonancestors_of()``
+    * ``remove_nondescendants_of()``
+    * ``substitute_node_with_dag()``
 
 - The ``qiskit.dagcircuit.DAGCircuit`` method ``rename_register()`` has been
   removed. This was unused by all the qiskit code. If you were relying on it
@@ -626,16 +627,17 @@ Upgrade Notes
 
 - The deprecated ``qiskit.mapper`` module has been removed. The list of
   functions and classes with their alternatives are:
-  * ``qiskit.mapper.CouplingMap``: ``qiskit.transpiler.CouplingMap`` should
-  be used instead.
-  * ``qiskit.mapper.Layout``: ``qiskit.transpiler.Layout`` should be used
-  instead
-  * ``qiskit.mapper.compiling.euler_angles_1q()``:
-  ``qiskit.quantum_info.synthesis.euler_angles_1q()`` should be used
-  instead
-  * ``qiskit.mapper.compiling.two_qubit_kak()``:
-  ``qiskit.quantum_info.synthesis.two_qubit_cnot_decompose()`` should be
-  used instead.
+
+    * ``qiskit.mapper.CouplingMap``: ``qiskit.transpiler.CouplingMap`` should
+      be used instead.
+    * ``qiskit.mapper.Layout``: ``qiskit.transpiler.Layout`` should be used
+      instead
+    * ``qiskit.mapper.compiling.euler_angles_1q()``:
+      ``qiskit.quantum_info.synthesis.euler_angles_1q()`` should be used
+      instead
+    * ``qiskit.mapper.compiling.two_qubit_kak()``:
+      ``qiskit.quantum_info.synthesis.two_qubit_cnot_decompose()`` should be
+      used instead.
 
   The deprecated exception classes ``qiskit.mapper.exceptions.CouplingError``
   and ``qiskit.mapper.exceptions.LayoutError`` don't have an alternative
@@ -749,11 +751,12 @@ Deprecation Notes
 
 - The module ``qiskit.pulse.ops`` has been deprecated. All the functions it
   provided:
-  * ``union``
-  * ``flatten``
-  * ``shift``
-  * ``insert``
-  * ``append``
+
+    * ``union``
+    * ``flatten``
+    * ``shift``
+    * ``insert``
+    * ``append``
   have equivalent methods available directly on the ``qiskit.pulse.Schedule``
   and ``qiskit.pulse.Instruction`` classes. Those methods should be used
   instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #471 two small mistakes were made in the documentation for the
release. The first is that we neglected to bump the docs version from
the previous release, 0.11.2, to the new release version 0.12.0. The
second issue was the date in the changelog for the release was 2 days
prior to the actual release. This commit corrects both oversights and
brings everything up to date. In addition some small tweaks are made
to the release notes formatting as the adjustments for the linter made
from the reno source in terra broke bulleted lists in a couple places.

### Details and comments