### PR TITLE
Remove unneeded line from 0.12.0 release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -136,9 +136,6 @@ Notable Changes
 Qiskit 0.12.0
 *************
 
-We have bumped up Qiskit micro version to 0.12.0 because Aer has
-bumped its minor version as well.
-
 .. _Release Notes_0.9.0:
 
 Terra 0.9


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Underneath the header for the 0.12.0 release notes there was a stray
sentence leftover from the original version of #471 justifying the bump
to 0.12.0. This is not accurate because the release included a release
of every element. Additionally we don't need to justify increasing the
version number in the release notes in general, we have a documented
versioning policy and release version numbers don't really mean
anything aside from that policy. This commit removes the sentence to
clean up the release notes slightly.

### Details and comments