### PR TITLE
Add a test to track mapper's performance on CNOT count

### DIFF
--- a/test/benchmarks/isometry.py
+++ b/test/benchmarks/isometry.py
@@ -48,11 +48,11 @@ class IsometryTranspileBench:
         return cnot_count
 
     def track_cnot_counts_after_mapping_to_ibmq_16_melbourne(self, *unused):
-        coupling_map = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
-                        [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],
-                        [11, 3], [11, 10], [11, 12], [12, 2], [13, 1], [13, 12]]
+        coupling = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
+                    [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],
+                    [11, 3], [11, 10], [11, 12], [12, 2], [13, 1], [13, 12]]
         circuit = transpile(self.circuit, basis_gates=['u1', 'u3', 'u2', 'cx'],
-                            coupling_map=coupling_map, seed_transpiler=0)
+                            coupling_map=coupling, seed_transpiler=0)
         counts = circuit.count_ops()
         cnot_count = counts.get('cx', 0)
         return cnot_count

--- a/test/benchmarks/isometry.py
+++ b/test/benchmarks/isometry.py
@@ -46,3 +46,13 @@ class IsometryTranspileBench:
         counts = circuit.count_ops()
         cnot_count = counts.get('cx', 0)
         return cnot_count
+
+    def track_cnot_counts_after_mapping_to_ibmq_16_melbourne(self, *unused):
+        coupling_map = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
+                        [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],
+                        [11, 3], [11, 10], [11, 12], [12, 2], [13, 1], [13, 12]]
+        circuit = transpile(self.circuit, basis_gates=['u1', 'u3', 'u2', 'cx'],
+                            coupling_map=coupling_map, seed_transpiler=0)
+        counts = circuit.count_ops()
+        cnot_count = counts.get('cx', 0)
+        return cnot_count


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Add a test case for tracking CNOT count after mapping to IBM Q 16 Melbourne using isometry circuits so that we can track the quality of mappings by default pass manager.
