### PR TITLE
Fix global code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-@derivation @lzdanski @SooluThomas @jaygambetta @nonhermitian
+# Global code owners:
+* @derivation @lzdanski @SooluThomas @jaygambetta @nonhermitian


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The code owners list had a syntax error, you need to specify the files
for codeowners to work. This commit sets the codeowners list to be
global which is the intent.

### Details and comments

The documentation for code owners is here:

https://help.github.com/en/articles/about-code-owners
