### PR TITLE
Swap order of keys for ssh-add in deploy_documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       sudo: true
     - python: "3.5"
       env: TOXENV=lint
-    - if: type = push
+    - if: branch = master AND type = push
       os: linux
       dist: xenial
       python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       sudo: true
     - python: "3.5"
       env: TOXENV=lint
-    - if: branch = master AND type = push
+    - if: type = push
       os: linux
       dist: xenial
       python: "3.7"

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -46,14 +46,10 @@ sphinx-intl update -p _build/gettext -l en
 echo "Setup ssh keys"
 pwd
 set -e
-# Add qiskit.org push key to ssh-agent
-openssl aes-256-cbc -K $encrypted_19594d4cf7cb_key -iv $encrypted_19594d4cf7cb_iv -in ../tools/github_deploy_key.enc -out github_deploy_key -d
-chmod 600 github_deploy_key
-eval $(ssh-agent -s)
-ssh-add github_deploy_key
 # Add poBranch push key to ssh-agent
 openssl enc -aes-256-cbc -d -in ../tools/github_poBranch_update_key.enc -out github_poBranch_deploy_key -K $encrypted_deploy_po_branch_key -iv $encrypted_deploy_po_branch_iv
 chmod 600 github_poBranch_deploy_key
+eval $(ssh-agent -s)
 ssh-add github_poBranch_deploy_key
 
 # Clone to the working repository for .po and pot files
@@ -86,7 +82,14 @@ git commit -m "Automated documentation update to add .po files from meta-qiskit"
 echo "git push"
 git push --quiet origin $TARGET_BRANCH_PO
 echo "********** End of pushing po to working repo! *************"
+# Delete keys
+ssh-add -D
 
+# Add qiskit.org push key to ssh-agent
+openssl aes-256-cbc -K $encrypted_19594d4cf7cb_key -iv $encrypted_19594d4cf7cb_iv -in ../tools/github_deploy_key.enc -out github_deploy_key -d
+chmod 600 github_deploy_key
+eval $(ssh-agent -s)
+ssh-add github_deploy_key
 # Clone the landing page repository.
 cd ..
 git clone --depth 1 $TARGET_REPOSITORY tmp


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit swaps the order we add keys to the ssh agent in
deploy_documentation script. It is currently failing on trying to push
to poBranch with a permission denied error, which is probably because
it's using the wrong key. This changes the script to verify that it
works when the only configured key is for the respective push.

### Details and comments