### PR TITLE
Ignore LOCALIZATION_CONTRIBUTORS from authors file

### DIFF
--- a/tools/generate_authors.py
+++ b/tools/generate_authors.py
@@ -33,9 +33,11 @@ def main(repos=None, output_path=None):
     authors = []
     emails = []
 
-    def generate_authors(git_dir):
+    def generate_authors(git_dir, meta=False):
         """Create AUTHORS file using git commits."""
         git_log_cmd = ['git', 'log', '--format=%aN|%aE', '--use-mailmap']
+        if meta:
+            git_log_cmd += ['--', ':!docs/LOCALIZATION_CONTRIBUTORS']
         tmp_authors = _run_shell_command(git_log_cmd, git_dir).split('\n')
         for author_str in tmp_authors:
             author, email = author_str.split('|')
@@ -45,7 +47,10 @@ def main(repos=None, output_path=None):
                 if email.lower() not in [x.lower() for x in emails]:
                     authors.append(author)
                     emails.append(email)
-        co_authors_raw = _run_shell_command(['git', 'log', '--use-mailmap'],
+        co_author_cmd = ['git', 'log', '--use-mailmap']
+        if meta:
+            co_author_cmd += ['--', ':!docs/LOCALIZATION_CONTRIBUTORS']
+        co_authors_raw = _run_shell_command(co_author_cmd,
                                             git_dir)
         co_authors = re.findall('Co-authored-by:.+', co_authors_raw,
                                 re.MULTILINE | re.I)
@@ -71,7 +76,10 @@ def main(repos=None, output_path=None):
         repo_name = repo.rsplit('/', 1)[-1]
         repo_dir = get_repo(repo, repo_name)
         with repo_dir as repo_dir_path:
-            generate_authors(repo_dir_path)
+            if repo_name == 'qiskit':
+                generate_authors(repo_dir_path, True)
+            else:
+                generate_authors(repo_dir_path)
 
     # Write out flat authors file
     authors = sorted(set(authors), key=lambda x: x.split()[-1])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The AUTHORS file is just for tracking those who have to the qiskit
project. However, changes to the docs/LOCALIZATION_CONTRIBUTORS file
in the Qiskit/qiskit repo are not actually contributions, it's a
workaround to enable translators to sign the cla. Translations are done
through another service, crowdin, however because translators need to
sign the CLA prior to contributing and crowdin has no such mechanism they
need to create a github PR to do so. This however is not actually an
indication of actual contribution just that they signed the CLA.
Translation contributions will be tracked separately using a different
mechanism eventually, but until then we don't want to accidently include
this CLA workflow in the AUTHORS file. This commit modifies the
generate_authors file to exclude this file from the git log used to
build the AUTHORS list.

### Details and comments