### PR TITLE
Update terra for the requirements list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,9 @@
 
 from setuptools import setup
 
-qiskit_terra = "qiskit_terra==0.9.0"
 
 requirements = [
-    qiskit_terra,
+    "qiskit-terra==0.9.0",
     "qiskit-aer==0.3.0",
     "qiskit-ibmq-provider==0.3.2",
     "qiskit-ignis==0.2.0",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The requirements list previously treated terra as a special case because
we used to have a workaround to facilitate a seamless upgrade from
Qiskit 0.6 (which became qiskit-terra) to Qiskit 0.7 (which is the
meta-package). In order to do this the terra version was stored in a
variable so it could be used in multiple places. However, this
workaround was removed in #304 but in that patch we kept the terra
version as a variable. This commit corrects the oversight and removes
the variable usage and treats the terra version in the requirements
list the same as the other elements.

### Details and comments