### PR TITLE
Fix locale output dir from tox gettext command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
   sphinx-intl
 commands =
   sphinx-build -b gettext docs/ docs/_build/gettext {posargs}
-  sphinx-intl update -p docs/_build/gettext -l en
+  sphinx-intl -c docs/conf.py update -p docs/_build/gettext -l en -d docs/locale
 
 [doc8]
 max-line-length=100


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When we switched to using tox the command for generating the translation
artifacts that need to get pushed to po branch was assuming that it was
run in `docs/` but tox runs by default from the dir where tox.ini lives
(for python testing that's a sane assumption). This broke the deploy
documentation script because the locale output is no longer where it
it's expected to be (because it uses the sphinx-intl defaults instead of
the configured output location). This commit fixes the command to both
have a hardcoded output directory of docs/locale and also use the config
file docs/conf.py.

### Details and comments


