### PR TITLE
Changed the lang for sphinx make gettext

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -58,7 +58,6 @@ git config user.name "Qiskit Autodeploy"
 git config user.email "qiskit@qiskit.org"
 
 echo "git rm -rf for the translation po files"
-# git rm -rf --ignore-unmatch $DOC_DIR_2/$SOURCE_LANG/**/*.po # Remove old po files
 git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/api \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/apidoc \

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -20,7 +20,6 @@ TARGET_DOC_DIR="documentation"
 SOURCE_DOC_DIR="docs/_build/html"
 SOURCE_DIR=`pwd`
 SOURCE_LANG='en'
-TRANSLATION_LANG='ja'
 
 SOURCE_REPOSITORY="git@github.com:Qiskit/qiskit.git"
 TARGET_BRANCH_PO="poBranch"
@@ -36,8 +35,8 @@ cd docs
 
 # Extract document's translatable messages into pot files
 # https://sphinx-intl.readthedocs.io/en/master/quickstart.html
-echo "Extract document's translatable messages into pot files: "
-tox -egettext -- -D language=$TRANSLATION_LANG
+echo "Extract document's translatable messages into pot files and generate po files"
+tox -egettext -- -D language=$SOURCE_LANG
 
 echo "Setup ssh keys"
 pwd
@@ -59,7 +58,7 @@ git config user.name "Qiskit Autodeploy"
 git config user.email "qiskit@qiskit.org"
 
 echo "git rm -rf for the translation po files"
-# git rm -rf --ignore-unmatch $DOC_DIR_2/$TRANSLATION_LANG/**/*.po # Remove old po files
+# git rm -rf --ignore-unmatch $DOC_DIR_2/$SOURCE_LANG/**/*.po # Remove old po files
 git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/api \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/apidoc \


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the logic to create `.po` files. 

Previously the `.po` files were generated from Japanese `.pot` files which is generated from `sphinx-build -b gettext` with `language=ja`. This will generate Japanese words on its own for some words like "Note", "Tip", "Warning" etc. So, the consequently created `.po` file will have the Japanese word in all languages. This commit sets the language to `en` to rectify this problem.



