### PR TITLE
Update path for generate bibtex script

### DIFF
--- a/tools/generate_bibtex.py
+++ b/tools/generate_bibtex.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 from pylatexenc.latexencode import utf8tolatex
 
-with open('../AUTHORS', 'r') as authors_file:
+with open('AUTHORS', 'r') as authors_file:
     authors = list([utf8tolatex(x.rstrip()) for x in authors_file])
 
-with open('../Qiskit.bib', 'w') as fd:
+with open('Qiskit.bib', 'w') as fd:
     fd.write("@misc{ Qiskit,\n")
     fd.write('       author = {%s},\n' % ' and '.join(authors))
     fd.write('       title = {Qiskit: An Open-source Framework for Quantum Computing},\n')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The generate_authors.py and generate_bibtex.py scripts are both expected
to be called from the repo root (so you call tools/generate_authors.py
for example) and that will update the files in your CWD. However the
generated_bibtex.py script was writing and reading the output files
assuming your CWD was the tools directory. In the near future calling
these tools will be automated as part of the release workflow and we
need to have the scripts work in the same manner. This commit updates
the generate_bibtex.py scripts so that it works the same way as
generate_authors.py.

### Details and comments


