### PR TITLE
Checkout all of git on docs builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
       python: "3.7"
       sudo: true
       script: tools/deploy_documentation.sh
+      git:
+        depth: false
     - if: tag IS present
       python: "3.6"
       env:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since switching to building release version tables dynamically in docs
builds (and in the future having support for multiple things being
built dynamically based on version)s the version table only shows the
latest tag. This is because the git checkout from travis by default is a
shallow checkout meaning the full history isn't there. So when the
custom sphinx directive used to build the versions table runs it only
finds a single version in the checkout. To address this commit changes
the travis config for the docs job to disable the shallow checkout and
have the docs job pull the full repo. [1] This should both fix the version
history table and also enable other git based dynamic docs generation in
the future.

### Details and comments
[1] https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth

