### PR TITLE
Corrected IBM Q Account redirection link

### DIFF
--- a/docs/theme/_templates/layout.html
+++ b/docs/theme/_templates/layout.html
@@ -51,7 +51,7 @@
         <a href="/aer">Aer</a>
         <a href="/aqua">Aqua</a>
         <a href="/ignis">Ignis</a>
-        <a href="ibmqaccount">IBM Q Account</a>
+        <a href="/ibmqaccount">IBM Q Account</a>
       </nav>
       <nav class="second">
         <a class="external" id="educationLink" href="https://community.qiskit.org/education">Community</a>


### PR DESCRIPTION

### Summary

This commit corrects IBM Q Account redirection link which is now https://qiskit.org/documentation/ibmqaccount
