### PR TITLE
Remove .po files of api/ and apidoc/ from poBranch

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -62,6 +62,10 @@ git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/api \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/apidoc \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/_*
+	
+# Remove api/ and apidoc/ to avoid confusion while translating
+rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
+	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/apidoc/
 
 # Copy the new rendered files and add them to the commit.
 echo "copy directory"


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes `.po` files of `api/` and `apidoc/` during the build, to avoid confusion for the translators.

### Details and comments

The translators are given instructions not to translate `api/` and `apidocs/` content because we don't really have to translate them  and that they are updated often. But since the `.po` files of `api/` and `apidoc/` are generated, lives in the `poBranch` and is viewed in CrowdIn, new translators get confused. So, this commit deletes the generated `.po` files of `api/` and `apidoc/` during the build.