### PR TITLE
remove .doctrees during build

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -56,11 +56,14 @@ for i in "${TRANSLATION_LANG[@]}"; do
     git rm -rf --ignore-unmatch $TARGET_DOC_DIR/$i/*.html \
         $TARGET_DOC_DIR/$i/_* \
         $TARGET_DOC_DIR/$i/apidoc \
-        $TARGET_DOC_DIR/$i/api
+        $TARGET_DOC_DIR/$i/api \
+        $TARGET_DOC_DIR/$i/.doctrees
+    # Remove .doctrees from newly build files
+    rm -rf $SOURCE_DIR/$SOURCE_DOC_DIR/$i/.doctrees
 done
 
-# Copy the new rendered files and add them to the commit.
 
+# Copy the new rendered files and add them to the commit.
 cp -r $SOURCE_DIR/$SOURCE_DOC_DIR/* $TARGET_DOC_DIR/
 git add $TARGET_DOC_DIR
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes `.doctrees` during the translation build.

fixes #585 

