### PR TITLE
Add class's __init__() docstring too

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,6 +277,7 @@ epub_title = project
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
+autoclass_content = 'both'
 
 # -- Extension configuration -------------------------------------------------
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now many classes document class constructors and their arguments
in the docstring for the `__init__()` methods of the class. However, by
default autodoc does not show these for the classes' documentation and
instead relies on only the class docstring. This commit sets the sphinx
autodoc config option [1] to use both the class and init docstring
together.

### Details and comments

[1] https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content
