### PR TITLE
Make version table extension work outside of git

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,10 @@ import subprocess
 from docutils import nodes
 from docutils.parsers.rst.directives.tables import Table
 from docutils.parsers.rst import Directive, directives
+from sphinx.util import logging
 
+
+logger = logging.getLogger(__name__)
 
 # -- Project information -----------------------------------------------------
 
@@ -293,8 +296,9 @@ class VersionHistory(Table):
                                 cwd=self.repo_root)
         stdout, stderr = proc.communicate()
         if proc.returncode > 0:
-            raise RuntimeError("%s failed with:\nstdout:\n%s\nstderr:\n%s\n"
-                               % (cmd, stdout, stderr))
+            logger.warn("%s failed with:\nstdout:\n%s\nstderr:\n%s\n"
+                        % (cmd, stdout, stderr))
+            return ''
         return stdout.decode('utf8')
 
     def get_versions(self, tags):
@@ -363,9 +367,11 @@ class VersionHistory(Table):
                                 stderr=subprocess.PIPE, cwd=self.repo_root)
         stdout, stderr = proc.communicate()
         if proc.returncode > 0:
-            raise RuntimeError("%s failed with:\nstdout:\n%s\nstderr:\n%s\n"
-                               % (cmd, stdout, stderr))
-        tags = stdout.decode('utf8').splitlines()
+            logger.warn("%s failed with:\nstdout:\n%s\nstderr:\n%s\n"
+                        % (cmd, stdout, stderr))
+            tags = []
+        else:
+            tags = stdout.decode('utf8').splitlines()
         versions = self.get_versions(tags)
         self.max_cols = len(self.headers)
         self.col_widths = self.get_column_widths(self.max_cols)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the custom sphinx extension used to
build a version table dynamically based on the git history for the meta
repository. It was built assuming the git data from the repo will always
be present. However, in some cases (namely zip downloads from github)
the checkout isn't actually a git repo. When this happened the git
commands this extension depends on would fail breaking the build. Since
this is a possible condition this changes the extension to treat the
failure as non-fatal and instead just retur an empty result. This means
the extension won't generate any entries in the table, since there isn't
any git history to parse for version info. But, it means you can
successfully build the docs outside of a git repo.

### Details and comments