### PR TITLE
Exclude qiskit-bot from author's list

### DIFF
--- a/tools/generate_authors.py
+++ b/tools/generate_authors.py
@@ -85,6 +85,8 @@ def main(repos=None, output_path=None):
     authors = sorted(set(authors), key=lambda x: (x.split()[-1], x.split()[:]))
     with open(output_path, 'w') as fd:
         for author in authors:
+            if author == 'qiskit-bot':
+                continue
             fd.write(author + '\n')
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Starting with the terra 0.9.1 release the qiskit-bot user account has
been used to run qiskit-bot [1] which is used to automate various
aspects of development and release workflows for qiskit. This includes
opening PRs to bump the meta repository at release time. Since this
leads to a commit with the author listed as qiskit-bot in the git log
when those commits are merged [2]. This has the side effect of creating
an entry in the authors list for the bot. Since it's not a real person
and not authoring a change outside of increasing versions as it's been
programmed, this commit excludes the qiskit-bot entry from the authors
list.

### Details and comments

[1] https://github.com/Qiskit/qiskit-bot
[2] https://github.com/Qiskit/qiskit/commit/fafa867ea3051a4ab649455cfb86d8e40c5f311a
