### PR TITLE
Remove stubs/

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -65,7 +65,8 @@ git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	
 # Remove api/ and apidoc/ to avoid confusion while translating
 rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
-	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/apidoc/
+	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/apidoc/ \
+	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/stubs/
 
 # Copy the new rendered files and add them to the commit.
 echo "copy directory"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit is to prevent `/stubs/*.po` files, which are apidocs related files, from being added to the poBranch . Since apidocs need not be localized, this directory shouldn't be added to the poBranch.

### Details and comments


