### PR TITLE
Parallelize sphinx builds for translated builds

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -19,7 +19,7 @@ SOURCE_REPOSITORY="https://github.com/Qiskit/qiskit.git"
 TARGET_DOC_DIR="documentation/locale/"
 SOURCE_DOC_DIR="docs/_build/html/locale"
 SOURCE_DIR=`pwd`
-TRANSLATION_LANG=("ja" "de" "pt")
+TRANSLATION_LANG="ja de pt"
 
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
 sudo apt-get install -y ./rclone.deb
@@ -35,13 +35,7 @@ cp -r docs_source/docs/. $SOURCE_DIR/docs/
 pushd $SOURCE_DIR/docs
 
 # Make translated document
-# make -e SPHINXOPTS="-Dlanguage='ja'" html
-for i in "${TRANSLATION_LANG[@]}"; do
-   echo $i;
-   sphinx-build -b html -D language=$i . _build/html/locale/$i
-   # Remove .doctrees from newly build files
-   rm -rf $SOURCE_DIR/$SOURCE_DOC_DIR/$i/.doctrees
-done
+parallel sphinx-build -b html -D language={} . _build/html/local/{} ::: $TRANSLATION_LANG
 
 popd
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now we're running the translated builds serially. This takes a lot
of time and will only get worse as we add more languages. To try and
mitigate this to a certain amount this removes the for loop in the
translated doc build with GNU parallel to run each translation build in
parallel. This should improve the speed of translation build jobs.

### Details and comments


