### PR TITLE
Remove `theme/` .po files

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -66,12 +66,14 @@ echo "git rm -rf for the translation po files"
 git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/api \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/apidoc \
+	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/theme \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/_*
 
 # Remove api/ and apidoc/ to avoid confusion while translating
 rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
 	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/apidoc/ \
-	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/stubs/
+	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/stubs/ \
+	$SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/theme/
 
 # Copy the new rendered files and add them to the commit.
 echo "copy directory"


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit is to remove the generated [`.po` files](https://github.com/Qiskit/qiskit/tree/poBranch/docs/locale/en/LC_MESSAGES/theme/autosummary) from `theme\` directory .




