### PR TITLE
Set logo-only to False

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ html_theme_path = ['.', sphinx_rtd_theme.get_html_theme_path()]
 # documentation.
 #
 html_theme_options = {
-    'logo_only': True,
+    'logo_only': False,
     'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,


### PR DESCRIPTION
### Summary

This commit adds a text - "Qiskit" along with the Qiskit logo in the Qiskit Documentation.

### Details and comments

<img width="294" alt="image" src="https://user-images.githubusercontent.com/11485594/69072709-26769100-09fa-11ea-881f-234b67a47b04.png">

