### PR TITLE
Travis CI: Add Python 3.8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,23 +15,19 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
-    - os: linux
-      dist: xenial
-      python: "3.7"
+    - python: "3.7"
       env: TOXENV=py37
-      sudo: true
-    - python: "3.5"
+    - python: "3.8"
+      env: TOXENV=py38
+    - python: "3.8"
       env: TOXENV=lint
     - if: branch = master AND type = push
-      os: linux
-      dist: xenial
-      python: "3.7"
-      sudo: true
+      python: "3.8"
       script: tools/deploy_documentation.sh
       git:
         depth: false
     - if: tag IS present
-      python: "3.6"
+      python: "3.8"
       env:
         - TWINE_USERNAME=qiskit
       install: pip install -U twine

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py35, py36, py37, pep8
+envlist = py35, py36, py37, py38, pep8
 skipsdist = True
 
 [testenv]
@@ -15,11 +15,12 @@ commands =
 
 [testenv:lint]
 deps =
-  pycodestyle
+  flake8
   pylint
   doc8
   ipython
 commands =
+  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   pycodestyle test
   pylint -rn --rcfile={toxinidir}/.pylintrc test
   doc8 docs


### PR DESCRIPTION
The sudo tag is now deprecated and Linux and Xenial are defaults.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
