### PR TITLE
change tox default targets to match travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py35, py36, py37, pep8
+envlist = py35, py36, py37, lint, docs
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
The tox default targets were not the same as travis, so passing tox
locally doesn't mean you'd pass tox in travis. This syncs that.

