### PR TITLE
Reformat localization contributor page by language

### DIFF
--- a/docs/LOCALIZATION_CONTRIBUTORS
+++ b/docs/LOCALIZATION_CONTRIBUTORS
@@ -1,27 +1,49 @@
+German (DE)
+
+Albert Frisch
+Philip Düe
+Joachim Schaefer
+
+
+Italian (IT)
+
+Edoardo Giusto
+
+
+Japanese (JA)
+
 Yuri Kobayashi
-Takehiko Amano
 Kifumi Numata
+Takehiko Amano
 Kazumasa Umezawa
 Kaori Namba
-Satoru Nagata
 Shohhei Fujio
-Omar Costa Hamido
+Satoru Nagata
 Ayumu Shiraishi
-Albert Frisch
 Shun Shirakawa
+
+
+Portuguese (PT)
+
+Omar Costa Hamido
+
+
+Brazilian Portuguese (PT-BR)
+
+Igor Monteiro Vieira
+
+
+Spanish-Mexico (ES-ME)
+
 Jose Luis Rodriguez Gomez
 Vanessa Hernandez Mateos
 Baltazar Rodriguez Tellez
 Blas Osvaldo Gonzalez Aceves
 Antonio Sanchez Ruiz
-Edoardo Giusto
 Juan Montalvo Godina
 Salvador Elías Venegas Andraca
 Walid El Maouaki
-Philip Düe
-Igor Monteiro Vieira
 Vicente Pina Canelles
 Adolfo Cruz
 Cristeam Caiola Pasquier
-Joachim Schaefer
 Arturo Acuaviva Huertos


### PR DESCRIPTION

### Summary

Organize list of contributors by language instead of chronological order.

### Details and comments

Cross-checked role in CrowdIn, PR request, and open localization issues to organize the contributor list by language they volunteer for.
