### PR TITLE
Changing placeholders for language

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
   - source: docs/locale/en/**/*.po
-    translation: /docs/locale/%two_letters_code%/**/%original_file_name%
+    translation: /docs/locale/%locale_with_underscore%/**/%original_file_name%


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The placeholder for language is changed to `local_with_underscore`. This is necessary because some of project languages share the same language code (such as Spanish, Mexico and Spanish or Portuguese, Brazilian and Portuguese)




