### PR TITLE
Sync setup.py to poBranch too

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -69,6 +69,7 @@ git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/apidoc_legacy \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/theme \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/_*
+    setup.py
 
 # Remove api/ and apidoc/ to avoid confusion while translating
 rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
@@ -80,10 +81,12 @@ rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
 # Copy the new rendered files and add them to the commit.
 echo "copy directory"
 cp -r $SOURCE_DIR/$DOC_DIR_PO/ docs/
+cp -r $SOURCE_DIR/setup.py .
 
 # git checkout translationDocs
 echo "add to po files to target dir"
 git add $DOC_DIR_PO
+git add setup.py
 
 # Commit and push the changes.
 git commit -m "Automated documentation update to add .po files from meta-qiskit" -m "[skip travis]" -m "Commit: $TRAVIS_COMMIT" -m "Travis build: https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the migration to having apidocs live solely in the individual
elements was that the sphinx builds now rely on having up to date
version info in the setup.py for the meta package. However, on poBranch
where we build the translated version of the docs we were never updating
setup.py. This currently results in broken builds because the sphinx
plugin for pulling the docs source from the released elements can't
parse the terra version info, but in the future it would also result in
apidocs that were out of sync for translated docs. This commit fixes
these by also syncing setup.py from master to poBranch as part of deploy
documentation.

### Details and comments


