### PR TITLE
Fix typo in deploy_documentation.sh

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -69,7 +69,6 @@ git rm -rf --ignore-unmatch $DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/*.po \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/apidoc_legacy \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/theme \
 	$DOC_DIR_PO/$SOURCE_LANG/LC_MESSAGES/_*
-    setup.py
 
 # Remove api/ and apidoc/ to avoid confusion while translating
 rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
@@ -81,7 +80,7 @@ rm -rf $SOURCE_DIR/$DOC_DIR_PO/en/LC_MESSAGES/api/ \
 # Copy the new rendered files and add them to the commit.
 echo "copy directory"
 cp -r $SOURCE_DIR/$DOC_DIR_PO/ docs/
-cp -r $SOURCE_DIR/setup.py .
+cp $SOURCE_DIR/setup.py .
 
 # git checkout translationDocs
 echo "add to po files to target dir"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #817 we added a step to sync setup.py to poBranch as part of
documentation deploy (as part of the en po file updateds. However, that
commit had a typo which prevented it from working. That being said it
was actually a good thing, because setup.py was added to the wrong spot
in the script. If the typo wasn't there we'd have run git rm setup.py
and removed it from poBranch. This commit fixes this issue (and the typo
by extension) so that we only do a cp of setup.py instead of removing
it.

### Details and comments


