### PR TITLE
Bump numpy on poBranch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         - twine upload dist/qiskit*tar.gz
 
 language: python
-install: pip install -U tox
+install: pip install -U tox virtualenv pip setuptools
 script:
   - tox
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+numpy>=1.16.3
 Sphinx>=1.8.3
 sphinx-rtd-theme
 sphinx-autodoc-typehints>=1.8.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The translated docs builds are failing because of Qiskit/qiskit-aer#592
which is caused by using a version of numpy incompatible with the pulse
simulator. This has been fixed in aer on master and the stable/0.4.0
branch pending a 0.4.1 release. But, until that is ready we need to
manual ensure we're using a newer numpy version to avoid this issue in
the docs builds.

### Details and comments