### PR TITLE
Remove parallel translation build in poBranch

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -35,8 +35,11 @@ rclone sync -v --exclude='locale/**' docs_source/docs docs
 pushd $SOURCE_DIR/docs
 
 # Make translated document
-sudo apt-get install parallel
-parallel sphinx-build -b html -D content_prefix=documentation -D language={} . _build/html/locale/{} ::: $TRANSLATION_LANG
+
+for i in ${TRANSLATION_LANG[@]}; do
+   echo $i;
+   sphinx-build -b html content_prefix=documentation -D language=$i . _build/html/locale/$i
+done
 
 popd
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The script for apidocs deletes `docs/apidoc` folder at the end. When sphinx-build runs in parallel, the folder `docs/apidoc` is getting deleted which errors the build with `FileNotFoundError`.

This commit removes the parallel execution.

