### PR TITLE
Split translation doc publish jobs for each language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,19 @@ matrix:
       script: travis_wait 45 tools/deploy_documentation.sh
       git:
         depth: false
+      env:
+        - TRANSLATION_LANG=de_DE
+    - if: branch = poBranch AND type = push
+      os: linux
+      dist: xenial
+      python: "3.7"
+      sudo: true
+      install: pip install -U -r requirements-dev.txt sphinx-intl qiskit
+      script: travis_wait 45 tools/deploy_documentation.sh
+      git:
+        depth: false
+      env:
+        - TRANSLATION_LANG=ja_JP
     - if: tag IS present
       python: "3.6"
       env:

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -19,7 +19,6 @@ SOURCE_REPOSITORY="https://github.com/Qiskit/qiskit.git"
 TARGET_DOC_DIR="documentation/locale/"
 SOURCE_DOC_DIR="docs/_build/html/locale"
 SOURCE_DIR=`pwd`
-TRANSLATION_LANG="ja_JP de_DE"
 
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
 sudo apt-get install -y ./rclone.deb
@@ -36,14 +35,11 @@ pushd $SOURCE_DIR/docs
 
 # Make translated document
 
-for i in ${TRANSLATION_LANG[@]}; do
-   echo $i;
-   sphinx-build -b html -D content_prefix=documentation -D language=$i . _build/html/locale/$i
-done
+sphinx-build -b html -D content_prefix=documentation -D language=$TRANSLATION_LANG . _build/html/locale/$TRANSLATION_LANG
 
 popd
 
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 
 echo "Pushing built docs to website"
-rclone sync ./docs/_build/html/locale IBMCOS:qiskit-org-website/documentation/locale
+rclone sync ./docs/_build/html/locale/$TRANSLATION_LANG IBMCOS:qiskit-org-website/documentation/locale/$TRANSLATION_LANG


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now we're stuck in a spot where the docs builds can't be run in
parallel locally and doing 2 language builds serially exceeds the
maximum time allowed for a travis job. This commit tries to workaround
this by splitting the jobs up so we have an individual job for each
language. This should avoid the parallel build constraint and avoid us
hitting the job time limit.

### Details and comments