### PR TITLE
Reduce number of parameters on pass benchmarks

### DIFF
--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -26,8 +26,8 @@ from .utils import random_circuit
 
 class PassBenchmarks:
 
-    params = ([1, 2, 5, 8, 14, 20],
-              [8, 128, 1024])
+    params = ([5, 14, 20],
+              [1024])
 
     param_names = ['n_qubits', 'depth']
     timeout = 300

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -24,8 +24,8 @@ from .utils import random_circuit
 
 
 class Collect2QPassBenchmarks:
-    params = ([1, 2, 5, 8, 14, 20],
-              [8, 128, 1024])
+    params = ([5, 14, 20],
+              [1024])
 
     param_names = ['n_qubits', 'depth']
     timeout = 300
@@ -56,8 +56,8 @@ class Collect2QPassBenchmarks:
 
 
 class CommutativeAnalysisPassBenchmarks:
-    params = ([1, 2, 5, 8, 14, 20],
-              [8, 128, 1024])
+    params = ([5, 14, 20],
+              [1024])
 
     param_names = ['n_qubits', 'depth']
     timeout = 300
@@ -90,8 +90,8 @@ class CommutativeAnalysisPassBenchmarks:
 
 
 class UnrolledPassBenchmarks:
-    params = ([1, 2, 5, 8, 14, 20],
-              [8, 128, 1024])
+    params = ([5, 14, 20],
+              [1024])
 
     param_names = ['n_qubits', 'depth']
     timeout = 300
@@ -115,8 +115,8 @@ class UnrolledPassBenchmarks:
 
 
 class PassBenchmarks:
-    params = ([1, 2, 5, 8, 14, 20],
-              [8, 128, 1024])
+    params = ([5, 14, 20],
+              [1024])
 
     param_names = ['n_qubits', 'depth']
     timeout = 300


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now the dedicated benchmark machine is spending too much time and
has a growing backlog of commits to benchmark. Part of this is the
introduction of the pass benchmarks which run over a wide sweep of
parameters which results in 18 different permustations of the
benchmark. This ends up being a large portion of the time spent
benchmarking. This commit decreases the number of parameters to be a
single circuit depth and only 3 qubit counts. This reduces the number of
permutations from 18 to 3.

### Details and comments