### PR TITLE
Stop showing verbose rclone progress and use travis wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       env: TOXENV=docs
     - if: branch = master AND type = push
       python: "3.7"
-      script: tools/deploy_documentation.sh
+      script: travis_wait 45 tools/deploy_documentation.sh
       git:
         depth: false
     - if: tag IS present

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -98,4 +98,4 @@ popd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress --exclude 'locale/**' ./docs/_build/html IBMCOS:qiskit-org-website/documentation
+rclone sync --exclude 'locale/**' ./docs/_build/html IBMCOS:qiskit-org-website/documentation


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The verbose output from using --progress with rclone uploads is hitting
the upper log size limit for large docs changes. This was originally
added in #807 so that we didn't have travis stop the CI job because the
upload took >10mins (with no output). To workaround both issues this
commit uses travis_wait and removes the --progress flag from rclone.

### Details and comments