### PR TITLE
Disable LookaheadSwap mapping benchmarks due to timeout.

### DIFF
--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -83,25 +83,26 @@ class PassBenchmarks:
         swap.property_set['layout'] = self.layout
         return swap.run(self.dag).count_ops().get('swap')
 
-    def time_lookahead_swap(self, _, __):
-        swap = LookaheadSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        swap.run(self.dag)
+    # Disable lookahead swap benchmarks due to timeout.
+    # def time_lookahead_swap(self, _, __):
+    #     swap = LookaheadSwap(self.coupling_map)
+    #     swap.property_set['layout'] = self.layout
+    #     swap.run(self.dag)
 
-    def peakmem_lookahead_swap(self, _, __):
-        swap = LookaheadSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        swap.run(self.dag)
+    # def peakmem_lookahead_swap(self, _, __):
+    #     swap = LookaheadSwap(self.coupling_map)
+    #     swap.property_set['layout'] = self.layout
+    #     swap.run(self.dag)
 
-    def track_lookahead_swap_depth(self, _, __):
-        swap = LookaheadSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        return swap.run(self.dag).depth()
+    # def track_lookahead_swap_depth(self, _, __):
+    #     swap = LookaheadSwap(self.coupling_map)
+    #     swap.property_set['layout'] = self.layout
+    #     return swap.run(self.dag).depth()
 
-    def track_lookahead_swap_swap_count(self, _, __):
-        swap = LookaheadSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        return swap.run(self.dag).depth().count_ops().get('swap')
+    # def track_lookahead_swap_swap_count(self, _, __):
+    #     swap = LookaheadSwap(self.coupling_map)
+    #     swap.property_set['layout'] = self.layout
+    #     return swap.run(self.dag).depth().count_ops().get('swap')
 
     def time_basic_swap(self, _, __):
         swap = BasicSwap(self.coupling_map)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The lookahead swap mapping passes timeout consistently and have generated no data (likely due to https://github.com/Qiskit/qiskit-terra/issues/2171 ) but cost roughly an hour of benchmarking runtime per terra commit.

```
mapping_passes.PassBenchmarks.peakmem_lookahead_swap [dedicated-benchmarking-softlayer-baremetal/virtualenv-py3.6]
started: 2020-03-12 01:28:32, duration: 15.0m
mapping_passes.PassBenchmarks.time_lookahead_swap [dedicated-benchmarking-softlayer-baremetal/virtualenv-py3.6]
started: 2020-03-12 00:22:45, duration: 15.0m
mapping_passes.PassBenchmarks.track_lookahead_swap_depth [dedicated-benchmarking-softlayer-baremetal/virtualenv-py3.6]
started: 2020-03-12 01:50:58, duration: 15.0m
mapping_passes.PassBenchmarks.track_lookahead_swap_swap_count [dedicated-benchmarking-softlayer-baremetal/virtualenv-py3.6]
started: 2020-03-12 02:05:59, duration: 15.0m
```

This commit disables these benchmarks while the problems are investigated.

### Details and comments

The following benchmarks also generate no data and should be looked at (but don't substantially impact runtime):

```
passes.PassBenchmarks.track_barrier_before_final_measurement
mapping_passes.PassBenchmarks.track_cxdirection_depth
mapping_passes.PassBenchmarks.track_basic_swap_swap_count
mapping_passes.PassBenchmarks.time_cxdirection
mapping_passes.PassBenchmarks.track_cxdirection_depth
```

