### PR TITLE
Add disassemble benchmarks and more permutations to assemble

### DIFF
--- a/test/benchmarks/assembler.py
+++ b/test/benchmarks/assembler.py
@@ -34,7 +34,6 @@ class AssemblerBenchmarks:
                                       conditional=True, seed=seed)
         self.circuits = [self.circuit] * number_of_circuits
 
-
     def time_assemble_circuit(self, _, __, ___):
         assemble(self.circuits)
 

--- a/test/benchmarks/assembler.py
+++ b/test/benchmarks/assembler.py
@@ -27,6 +27,7 @@ class AssemblerBenchmarks:
               [1, 5, 10, 50, 100])
     param_names = ['n_qubits', 'depth', 'number of circuits']
     timeout = 600
+    version = 2
 
     def setup(self, n_qubits, depth, number_of_circuits):
         seed = 42

--- a/test/benchmarks/assembler.py
+++ b/test/benchmarks/assembler.py
@@ -16,20 +16,42 @@
 # pylint: disable=attribute-defined-outside-init,unsubscriptable-object
 
 from qiskit.compiler import assemble
+from qiskit.assembler import disassemble
 
 from .utils import random_circuit
 
 
 class AssemblerBenchmarks:
     params = ([1, 2, 5, 8],
-              [8, 128, 1024, 2048, 4096])
-    param_names = ['n_qubits', 'depth']
+              [8, 128, 1024, 2048, 4096],
+              [1, 5, 10, 50, 100])
+    param_names = ['n_qubits', 'depth', 'number of circuits']
     timeout = 600
 
-    def setup(self, n_qubits, depth):
+    def setup(self, n_qubits, depth, number_of_circuits):
         seed = 42
         self.circuit = random_circuit(n_qubits, depth, measure=True,
                                       conditional=True, seed=seed)
+        self.circuits = [self.circuit] * number_of_circuits
 
-    def time_assemble_circuit(self, _, __):
-        assemble(self.circuit)
+
+    def time_assemble_circuit(self, _, __, ___):
+        assemble(self.circuits)
+
+
+class DisassemblerBenchmarks:
+    params = ([1, 2, 5, 8],
+              [8, 128, 1024, 2048, 4096],
+              [1, 5, 10, 50, 100])
+    param_names = ['n_qubits', 'depth', 'number of circuits']
+    timeout = 600
+
+    def setup(self, n_qubits, depth, number_of_circuits):
+        seed = 424242
+        self.circuit = random_circuit(n_qubits, depth, measure=True,
+                                      conditional=True, seed=seed)
+        self.circuits = [self.circuit] * number_of_circuits
+        self.qobj = assemble(self.circuits)
+
+    def time_disassemble_circuit(self, _, __, ___):
+        disassemble(self.qobj)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit expands our coverage of the assemble benchmarks by adding
assembly cases with >1 circuit. At the same time this adds a second
benchmark class which adds coverage for qobj disassemble.

### Details and comments