### PR TITLE
Add travis job to run pip check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ jobs:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
-    - python: "3.7"
-      install: pip install -U pip virtualenv setuptools
-      script:
-        - pip install -U .
-        - pip check
     - python: "3.5"
       env: TOXENV=lint
     - if: branch = master AND type = push

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ jobs:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
+    - python: "3.7"
+      install: pip install -U pip virtualenv setuptools
+      script:
+        - pip install -U .
+        - pip check
     - python: "3.5"
       env: TOXENV=lint
     - if: branch = master AND type = push

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
 commands =
+  pip check
   python -m unittest -v
 
 [testenv:lint]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The new pip depsolver is coming this summer. [1] Until it's ready
this starts running pip check as a travis job to make sure we're
not somehow installing conflicting package versions. We shouldn't
be, but if we are better to know and start preparing/fixing it
now.


### Details and comments

[1] https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html