### PR TITLE
Install pygments via asv to unblock benchmark runs

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -25,6 +25,7 @@
         "return-code=any python -c \"import shutil; shutil.rmtree('{build_dir}/build')\"",
         "return-code=any python -c \"import shutil; shutil.rmtree('{build_dir}/qiskit_terra.egg-info')\"",
         "python -mpip install seaborn",
+        "python -mpip install pygments",
         "python -mpip install {wheel_file}",
         "python -mpip install -U qiskit-ignis==0.2.0",
         "python -mpip install -U python-constraint"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#3861 a new requirement was added to terra without
updating the requirements list in the setup.py. This causes issues when
trying to run the benchmarks for commits after that PR and prior to
Qiskit/qiskit-terra#4045 merging because it can't actually install
terra. This commit adds pygments to the asv.conf.json to ensure we can
have continuous benchmarking.

### Details and comments