### PR TITLE
Add new planned maintenance error code

### DIFF
--- a/docs/errors/errors.rst
+++ b/docs/errors/errors.rst
@@ -64,6 +64,12 @@ Error codes       Messages
                   :Solution: Wait until some previous jobs were finished.
                              You can cancel pending jobs to run new jobs.
 
+**1999**          :Error message: Planned outage. The service is undergoing
+                                  maintenance.
+                  :Solution: Please wait. The service will be back up soon.
+                             The website portal will have more information
+                             about what the expected time window for the
+                             maintenance work is.
 ================  ============================================================
 
 


### PR DESCRIPTION
### Summary

This adds a new error code to let api users know, including
qiskit providers, when the service is out for maintenance.

### Details and comments

Fixes #793