### PR TITLE
Add missing ssh key setup from poBranch update script

### DIFF
--- a/tools/deploy_translatable_strings.sh
+++ b/tools/deploy_translatable_strings.sh
@@ -36,6 +36,14 @@ pushd docs
 echo "Extract document's translatable messages into pot files and generate po   files"
 tox -egettext -- -D language=$SOURCE_LANG
 
+echo "Setup ssh keys"
+pwd
+set -e
+# Add poBranch push key to ssh-agent
+openssl enc -aes-256-cbc -d -in ../tools/github_poBranch_update_key.enc -out github_poBranch_deploy_key -K $encrypted_deploy_po_branch_key -iv $encrypted_deploy_po_branch_iv
+chmod 600 github_poBranch_deploy_key
+eval $(ssh-agent -s)
+ssh-add github_poBranch_deploy_key
 
 # Clone to the working repository for .po and pot files
 popd


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #880 we split the poBranch update script out into a separate job and
script. But as part of that a copy and paste error missed the setup
section for configuring the ssh key needed to actually be able to push
to poBranch. This commit corrects the oversight and adds back the
missing configuration to deploy_translatable_strings.sh so that job can
succeed.

### Details and comments