### PR TITLE
Fix typo in recent release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1452,8 +1452,8 @@ Bug Fixes
   to render :class:`~qiskit.extensions.CU1Gate` gates correctly.
   Fixes `#3684 <https://github.com/Qiskit/qiskit-terra/issues/3684>`_
 
-- A bug in :meth`qiskit.circuit.QuantumCircuit.from_qasm_str` and
-  :meth`qiskit.circuit.QuantumCircuit.from_qasm_file` when
+- A bug in :meth:`qiskit.circuit.QuantumCircuit.from_qasm_str` and
+  :meth:`qiskit.circuit.QuantumCircuit.from_qasm_file` when
   loading QASM with custom gates defined has been fixed. Now, loading
   this QASM::
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the most recent release notes from terra there was a small typo in
the markup for one of the bug fix notes with a missing ':' around the
`:meth:` command to link to the method documentation. This commit
corrects the oversight to fix the link.

### Details and comments