### PR TITLE
Compress docs prior to upload

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,14 @@ steps:
 - bash: |
     tox -edocs
   displayName: 'Run Docs Build'
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: 'docs/_build/html'
+    archiveType: tar
+    archiveFile: '$(Build.ArtifactStagingDirectory)/html_docs.tar.gz'
+    verbose: true
 - task: PublishBuildArtifacts@1
   displayName: 'Publish docs'
   inputs:
-    pathtoPublish: 'docs/_build/html'
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'html_docs'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now the docs jobs spend a considerable amount of time uploading
the output from the compiled documentation. This commit mitigates that
impact by compressing the built docs directoy prior to uploading. This
way the upload task is very quick since it only needs to upload a single
file.

### Details and comments