### PR TITLE
Increase travis wait timeout and enable parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ jobs:
       env: TOXENV=lint
     - if: branch = master AND type = push
       python: "3.7"
-      script: travis_wait 45 tools/deploy_documentation.sh
+      script: travis_wait 50 tools/deploy_documentation.sh
       git:
         depth: false
     - if: branch = master AND type = push
       python: "3.7"
-      script: travis_wait 45 tools/deploy_translatable_strings.sh
+      script: travis_wait 50 tools/deploy_translatable_strings.sh
       git:
         depth: false
     - if: tag IS present

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
     sudo apt-get install -y pandoc graphviz
   displayName: 'Install dependencies'
 - bash: |
-    tox -edocs
+    tox -edocs -- -j auto
   displayName: 'Run Docs Build'
 - task: ArchiveFiles@2
   inputs:

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -20,7 +20,7 @@ sudo apt-get install -y ./rclone.deb
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
 # Build the documentation.
-tox -edocs -- -D content_prefix=documentation
+tox -edocs -- -D content_prefix=documentation -j auto
 
 echo "show current dir: "
 pwd


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The combined doc job is taking over 45 mins to build and upload
currently. While the docs builds finishes the job exits because of a
timeout while uploading the new files to object storage. This commit
attempts to mitigate this by increasing the `travis_wait `timeout to 50min
which is the maximum job run time allowed by travis. Also in an attempt
to build the documentation faster the sphinx-build -j flag is used to parallelize the
build across both vCPUs on the ci nodes. This should hopefully provide
enough of a margin to build the documentation.

### Details and comments
