### PR TITLE
Remove typehints plugin to try and fix deprecation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
-    'sphinx_autodoc_typehints',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'sphinx_tabs.tabs',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the autodoc typehints module in an attempt to fix
the deprecation warnings on sphinx >3.0.0 that are raised by every
function signature that uses type hints. Sphinx is supposed to have
native support for typehints this commit is to see if the output from
the docs builds with type hints are formatted decently without the
plugin and to see if the type hints go away.

### Details and comments

Fixes #911 