### PR TITLE
Add minimum numpy version to requirements-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ matrix:
       dist: xenial
       python: "3.7"
       sudo: true
-      install: pip install -U -r requirements-dev.txt sphinx-intl qiskit
+      install:
+        - pip install -U pip virtualenv setuptools wheel
+        - pip install -U -r requirements-dev.txt sphinx-intl qiskit
       script: travis_wait 45 tools/deploy_documentation.sh
       git:
         depth: false
@@ -40,7 +42,9 @@ matrix:
       dist: xenial
       python: "3.7"
       sudo: true
-      install: pip install -U -r requirements-dev.txt sphinx-intl qiskit
+      install:
+        - pip install -U pip virtualenv setuptools wheel
+        - pip install -U -r requirements-dev.txt sphinx-intl qiskit
       script: travis_wait 45 tools/deploy_documentation.sh
       git:
         depth: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+numpy>=1.17
 Sphinx>=1.8.3
 sphinx-rtd-theme
 sphinx-autodoc-typehints>=1.8.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a minimum numpy version to the requirements list to fix
the translated docs builds with qiskit>=0.18.3. Since Aer 0.5.1 the
minimum numpy version hasn't been satisifed and because of pip's lack of
a dependency solver it's unable to install the newer version that's
conflicting with the pre-installed system python numpy version. This
commit adds an explicit requirement on the minimum numpy version to
ensure that install a new enough version prior to building the docs.
At the same time the version of pip, setuptools, etc are also updated
for the docs build jobs to ensure that we have a new enough version
installed.

### Details and comments