### PR TITLE
Fix typo in installation instructions.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -82,7 +82,7 @@ To simplify your experience we also recommend installing the following
 .. code:: sh
 
   pip install matplotlib
-  pip install juypter
+  pip install jupyter
   pip install ipywidgets
   pip install seaborn
   pip install pygments


### PR DESCRIPTION
### Summary

There is a typo `juypter` instead of `jupyter` in the installation instructions. 

### Details and comments

Fixing the typo makes it possible to copy the instructions into a terminal. Currently, this fails.
