### PR TITLE
Correct oversight in po sync job

### DIFF
--- a/tools/deploy_translatable_strings.sh
+++ b/tools/deploy_translatable_strings.sh
@@ -48,7 +48,7 @@ ssh-add github_poBranch_deploy_key
 popd
 pwd
 echo "git clone for working repo"
-git clone --depth 1 $SOURCE_REPOSITORY temp --single-branch --branch $TARGET_BRANCH_PO
+git clone --depth 1 $TARGET_REPOSITORY temp --single-branch --branch $TARGET_BRANCH_PO
 pushd temp
 
 git config user.name "Qiskit Autodeploy"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #938 the process of switching the repo where translations run to
qiskit-community/qiskit-translations was started by updating the deploy
script to push to that repo instead of poBranch on qiskit/qiskit.
However, in that change the script was updated to push the output to a
different repo but missed updating the actual cloning a working copy of
the dest repo. This commit corrects the oversight.

### Details and comments


