### PR TITLE
Add reverse CI job for building tutorials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,17 @@ jobs:
       env: TOXENV=py38
     - python: "3.5"
       env: TOXENV=lint
+    - python: "3.8"
+      script:
+        - git clone https://github.com/Qiskit/qiskit-tutorials
+        - python -m pip install --upgrade pip setuptools wheel virtualenv
+        - virtualenv /tmp/docs_build
+        - source /tmp/docs_build/bin/activate
+        - pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme qiskit-terra[visualization] cvxpy
+        - pip install -U .
+        - sudo apt-get install -y pandoc graphviz
+        - cd qiskit-tutorials
+        - sphinx-build -b html . _build/html
     - if: branch = master AND type = push
       python: "3.7"
       script: travis_wait 50 tools/deploy_documentation.sh


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The qiskit-tutorials repo is using the qiskit metapackage to install
qiskit and running the tutorials in CI. However, we do not have a job in
place to verify that a pending release will not break the tutorials.
Normally we would do this as part of a docs build but because of our
limited time budget we can't do a full doc build and tutorial build in
the same job. This commit just runs the tutorials sphinx build like it
does in the tutorials CI, but uses master from Qiskit/qiskit. This way
we'll catch any issues in a pending release prior to pushing the tag.

### Details and comments