### PR TITLE
Pivot to github actions instead of travis for docs publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Docs Publish
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U virtualenv setuptools wheel tox
+        sudo apt-get install graphviz pandoc
+    - name: Build and publish
+      env:
+        encrypted_rclone_key: ${{ secrets.encrypted_rclone_key }}
+        encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
+      run: |
+        tools/deploy_documentation.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,6 @@ jobs:
         - sphinx-build -b html . _build/html
     - if: branch = master AND type = push
       python: "3.7"
-      script: travis_wait 50 tools/deploy_documentation.sh
-      git:
-        depth: false
-    - if: branch = master AND type = push
-      python: "3.7"
       script: travis_wait 50 tools/deploy_translatable_strings.sh
       git:
         depth: false

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -28,4 +28,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --exclude 'locale/**' ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation
+rclone sync --progress --exclude 'locale/**' ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The documentation builds and upload time for the publish job can
consistently take well over 1 hour. The travis jobs have a hard limit
of 50min and this is similar in other CI systems like azure-pipelines
(60 mins). According to the docs for github actions the job
timeout is 6 hours [1] which should be more than enough for the docs
builds. This commit adds an initial workflow for publish docs and
removes the travis job config for publishing the docs so we will
rely on a post merge action to build and publish the documentation
moving forward.

### Details and comments

[1] https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#usage-limits