### PR TITLE
Unblock docs publish job

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ ipywidgets>=7.3.
 pillow>=4.2.1
 seaborn>=0.9.0
 nbsphinx
+cvxpy<1.1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recent ignis 0.3.2 (and 0.3.1, but that had other bugs) release a
bug slipped in that crashes ignis if cvxpy is not installed. This is
causing the docs jobs to fail to build any documentation that ends up
importing process tomography (see Qiskit/qiskit-ignis#429). This commit
explicitly adds cvxpy to the docs jobs to unblock them so we upload
complete documentation. An ignis bugfix release 0.3.3 will be out soon
to fix the ignis bug, but until then this will fix the hosted
documentation.

### Details and comments


