### PR TITLE
Updated docs/install.rst. Fixes issue #894

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -160,7 +160,7 @@ returns only the version for the ``qiskit-terra`` package. This is because
 the ``qiskit`` namespace in Python doesn't come from the Qiskit package, but
 instead is part of the ``qiskit-terra`` package.
 
-.. jupyter-execute::
+.. code::
 
    import qiskit
    qiskit.__version__

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,37 +33,28 @@ included with Anaconda. A Conda environment allows you to specify a specific
 version of Python and set of libraries. Open a terminal window in the directory
 where you want to work.
 
+It is preferred is you use Conda prompt installed with the Anaconda. 
+All you have to do is create a virtual environment in Anaconda and activate the environment. 
+These commands can be run in Anaconda prompt irrespective of Windows or linux machine.
+
 Create a minimal environment with only Python installed in it.
 
 .. code:: sh
 
   conda create -n name_of_my_env python=3
 
-If you are using conda version 4.6 or above, which is recommended, use following command to activate your environment:
+Activate your new environment.
+.. code:: sh
 
   conda activate name_of_my_env
-This command can be used irrespective of Windows or Unix/Linux. Simply type these commands in anaconda prompt.
 
 
-.. code:: sh
+.. note::
+  If you are using conda versions prior to 4.6, use:
+   
+    For Linux or macOS: ``source activate name_of_my_env``
+    For Windows: ``activate name_of_my_env``
 
-  source activate name_of_my_env
-
-Or, if you're using Windows
-
-1. Install Anaconda
-2. Search for Anaconda Prompt
-3. Open Anaconda Prompt
-
-Use the following commands
-
-.. code:: sh
-
-  conda create -n name_of_my_env python=3
-
-.. code:: sh
-
-  activate name_of_my_env
 
 
 Next, install the Qiskit package, which includes Terra, Aer, Ignis, and Aqua.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -44,12 +44,14 @@ Create a minimal environment with only Python installed in it.
   conda create -n name_of_my_env python=3
 
 Activate your new environment.
+
 .. code:: sh
 
   conda activate name_of_my_env
 
 
 .. note::
+
   If you are using conda versions prior to 4.6, use:
    
     For Linux or macOS: ``source activate name_of_my_env``

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -160,7 +160,7 @@ returns only the version for the ``qiskit-terra`` package. This is because
 the ``qiskit`` namespace in Python doesn't come from the Qiskit package, but
 instead is part of the ``qiskit-terra`` package.
 
-.. jupyter-executive::
+.. jupyter-execute::
 
    import qiskit
    qiskit.__version__

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -94,7 +94,7 @@ versions of macOS) you'll need to put ``qiskit[visualization]`` in quotes:
   After you've installed and verified the Qiskit packages you want to use, import
   them into your environment with Python to begin working.
 
-.. jupyter-executive:: python
+.. jupyter-execute::
 
   import qiskit
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,7 +53,7 @@ Activate your new environment.
 .. note::
 
   If you are using conda versions prior to 4.6, use:
-   
+  
     For Linux or macOS: ``source activate name_of_my_env``
     For Windows: ``activate name_of_my_env``
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,8 +33,8 @@ included with Anaconda. A Conda environment allows you to specify a specific
 version of Python and set of libraries. Open a terminal window in the directory
 where you want to work.
 
-It is preferred is you use Conda prompt installed with the Anaconda. 
-All you have to do is create a virtual environment in Anaconda and activate the environment. 
+It is preferred is you use Conda prompt installed with the Anaconda.
+All you have to do is create a virtual environment in Anaconda and activate the environment.
 These commands can be run in Anaconda prompt irrespective of Windows or linux machine.
 
 Create a minimal environment with only Python installed in it.
@@ -94,7 +94,7 @@ versions of macOS) you'll need to put ``qiskit[visualization]`` in quotes:
   After you've installed and verified the Qiskit packages you want to use, import
   them into your environment with Python to begin working.
 
-.. code:: python
+.. jupyter-executive:: python
 
   import qiskit
 
@@ -160,7 +160,7 @@ returns only the version for the ``qiskit-terra`` package. This is because
 the ``qiskit`` namespace in Python doesn't come from the Qiskit package, but
 instead is part of the ``qiskit-terra`` package.
 
-.. code::
+.. jupyter-executive::
 
    import qiskit
    qiskit.__version__

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -60,6 +60,10 @@ Use the following commands
 
   activate name_of_my_env
 
+If you are using conda version 4.6 or above, which is recommended, use following command to activate your environment:
+
+  conda activate name_of_my_env
+
 Next, install the Qiskit package, which includes Terra, Aer, Ignis, and Aqua.
 
 .. code:: sh

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,8 +33,8 @@ included with Anaconda. A Conda environment allows you to specify a specific
 version of Python and set of libraries. Open a terminal window in the directory
 where you want to work.
 
-It is preferred is you use Conda prompt installed with the Anaconda.
-All you have to do is create a virtual environment in Anaconda and activate the environment.
+It is preferred that you use Anaconda prompt installed with the Anaconda.
+All you have to do is create a virtual environment inside Anaconda and activate the environment.
 These commands can be run in Anaconda prompt irrespective of Windows or linux machine.
 
 Create a minimal environment with only Python installed in it.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -94,7 +94,7 @@ versions of macOS) you'll need to put ``qiskit[visualization]`` in quotes:
   After you've installed and verified the Qiskit packages you want to use, import
   them into your environment with Python to begin working.
 
-.. jupyter-execute::
+.. code:: python
 
   import qiskit
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,9 +53,8 @@ Activate your new environment.
 .. note::
 
   If you are using conda versions prior to 4.6, use:
-  
-    For Linux or macOS: ``source activate name_of_my_env``
-    For Windows: ``activate name_of_my_env``
+  For Linux or macOS: ``source activate name_of_my_env``
+  For Windows: ``activate name_of_my_env``
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,6 +39,11 @@ Create a minimal environment with only Python installed in it.
 
   conda create -n name_of_my_env python=3
 
+If you are using conda version 4.6 or above, which is recommended, use following command to activate your environment:
+
+  conda activate name_of_my_env
+This command can be used irrespective of Windows or Unix/Linux. Simply type these commands in anaconda prompt.
+
 
 .. code:: sh
 
@@ -60,9 +65,6 @@ Use the following commands
 
   activate name_of_my_env
 
-If you are using conda version 4.6 or above, which is recommended, use following command to activate your environment:
-
-  conda activate name_of_my_env
 
 Next, install the Qiskit package, which includes Terra, Aer, Ignis, and Aqua.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The file "install.rst" in docs explained creating and activating a anaconda environment. It showed the following command.
`source activate name_of_my_env`
However, for new anaconda version (>4.6), this command is depreciated and instead following command is used.
`conda activate name_of_my_env`

This has been updated in the file.

### Details and comments
Working on qiskit using anaconda is very important. More than virtual environments, anaconda is preferred by many people. `source activate` or `activate` is a command for older versions of anaconda. New versions are depreciating this command and for following versions, this command might not even be recognized. Hence, _this pull request updates the docs_ by giving instructions for new version.
While installing, anaconda still gets installed with older versions and many people may not update it. Therefore, the _older command is not deleted_. Just new command is added for current and future version of anacoda.

