### PR TITLE
Cap matplotlib and add set -e to deploy script

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ sphinx-tabs>=1.1.11
 sphinx-automodapi
 jupyter
 jupyter-sphinx
-matplotlib>=2.1
+matplotlib>=2.1,<3.3.0
 pydot
 ipywidgets>=7.3.
 pillow>=4.2.1

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -13,6 +13,7 @@
 # that they have been altered from the originals.
 
 # Script for pushing the documentation to the qiskit.org repository.
+set -e
 
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
 sudo apt-get install -y ./rclone.deb


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent matplotlib broke the hinton plotter (which has been fixed on
terra master) and the documentation fails to build now when it runs the
docs for the hinton plot function. Because the deploy script was missing
a set -e the failed documentation build didn't stop the script and it
continued to run a sync on empty directory which lead to the
documentation getting deleted. This commit fixes the docs builds by
pinning matplotlib until the next terra release and setting set -e on
the deploy script so we the documentation doesn't accidentally get deleted
when the docs build fails.

### Details and comments


