### PR TITLE
Fix the tutorials job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - python -m pip install --upgrade pip setuptools wheel virtualenv
         - virtualenv /tmp/docs_build
         - source /tmp/docs_build/bin/activate
-        - pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme qiskit-terra[visualization] cvxpy
+        - pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme matplotlib<3.3.0 qiskit-terra[visualization] cvxpy
         - pip install -U .
         - sudo apt-get install -y pandoc graphviz
         - cd qiskit-tutorials

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - python -m pip install --upgrade pip setuptools wheel virtualenv
         - virtualenv /tmp/docs_build
         - source /tmp/docs_build/bin/activate
-        - pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme matplotlib<3.3.0 qiskit-terra[visualization] cvxpy
+        - pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy
         - pip install -U .
         - sudo apt-get install -y pandoc graphviz
         - cd qiskit-tutorials


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent release of matplotlib 3.3.0 broke the plot_state_hinton
visualization function (see Qiskit/qiskit-terra#4739 for more details).
This has resulted in docs builds and tutorials using released version of
qiskit-terra to fail when they go to use plot_state_hinton. This broke
the docs builds and end up wiping out the documentation see #973. While
that has been fixed for documentation the tutorials build jobs are still
broken because they do not cap matplotlib. This commit adds a cap on
matplotlib to unbreak the job. When the next qiskit-terra release comes
out we can remove the version cap.

### Details and comments


