### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -126,14 +126,14 @@ To configure your account, you create a local configuration file which includes 
 
 **2.**  Navigate to **My Account** to view your account settings.
 
-.. image:: /images/figures/install_0.png
+.. image:: images/figures/install_0.png
    :alt: Image of where to find the section 'My accounts'.
 
 **3.** Click on **Copy token** to copy the token to your clipboard.
 Temporarily paste this API token into your favorite text editor so you can use it later to create
 an account configuration file.
 
-.. image:: /images/figures/install_1.png
+.. image:: images/figures/install_1.png
    :alt: Image of where to get an API token.
 
 **4.** Run the following commands to store your API token locally for later use in a


### PR DESCRIPTION
fix broken image links mentioned in #993 

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

### Summary
fix broken image links mentioned in #993 

### Details and comments
The required images already exist in the specified folder. The .rst file had the path to images starting with "/". I have removed the first character "/" of the path to pick the images from the right path.

