### PR TITLE
Increase nbsphinx timeout to 5 mins

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ extensions = [
     'nbsphinx'
 ]
 
-nbsphinx_timeout = 60
+nbsphinx_timeout = 300
 nbsphinx_execute = os.getenv('QISKIT_DOCS_BUILD_TUTORIALS', 'never')
 nbsphinx_widgets_path = ''
 html_sourcelink_suffix = ''


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Prior to #989 we were just deploying prebuilt tutorials in the docs
publish jobs so the per cell timeout was set to 60sec which should have
been plenty since nothing was executed. However after #989 in the docs
deploy job we started executing all the cells. The 60 sec timeout is not
sufficient for that, especially considering the tutorials repo has a
3min per cell timeout. This commit bumps the timeout to 5min to give a
healthy margin on the publish job, where there isn't really any time
pressure.

### Details and comments


