### PR TITLE
Remove redundant docs job from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,6 @@ jobs:
       env: TOXENV=py38
     - python: "3.5"
       env: TOXENV=lint
-    - python: "3.8"
-      script:
-        - git clone https://github.com/Qiskit/qiskit-tutorials
-        - python -m pip install --upgrade pip setuptools wheel virtualenv
-        - virtualenv /tmp/docs_build
-        - source /tmp/docs_build/bin/activate
-        - pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4'
-        - pip install -U .
-        - sudo apt-get install -y pandoc graphviz
-        - cd qiskit-tutorials
-        - sphinx-build -b html . _build/html
     - if: branch = master AND type = push
       python: "3.7"
       script: travis_wait 50 tools/deploy_translatable_strings.sh


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Both the travis CI tests and azure builds docs in every opened PR. The travis docs job runs for approx 20 minutes and azure for 47 minutes. This PR intends to remove one of the jobs to save some CI tests time.

### Details and comments


