### PR TITLE
Add back translatable string job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,3 +26,25 @@ jobs:
         QISKIT_DOCS_BUILD_TUTORIALS: 'always'
       run: |
         tools/deploy_documentation.sh
+  deploy-translatable-strings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U virtualenv setuptools wheel tox
+        sudo apt-get install graphviz pandoc
+    - name: Build and publish
+      env:
+        encrypted_deploy_po_branch_key: ${{ secrets.encrypted_deploy_po_branch_key }}
+        encrypted_deploy_po_branch_iv: ${{ secrets.encrypted_deploy_po_branch_iv }}
+        QISKIT_DOCS_BUILD_TUTORIALS: 'always'
+      run: |
+        tools/deploy_translatable_strings.sh

--- a/tools/deploy_translatable_strings.sh
+++ b/tools/deploy_translatable_strings.sh
@@ -82,7 +82,7 @@ git add setup.py
 git add requirements-dev.txt
 
 # Commit and push the changes.
-git commit -m "Automated documentation update to add .po files from meta-qiskit" -m "skip ci" -m "Commit: $TRAVIS_COMMIT" -m "Travis build: https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
+git commit -m "Automated documentation update to add .po files from meta-qiskit" -m "skip ci" -m "Commit: $GITHUB_SHA" -m "Github Actions Run: https://github.com/Qiskit/qiskit/runs/$GITHUB_RUN_NUMBER"
 echo "git push"
 git push --quiet origin $TARGET_BRANCH_PO
 echo "********** End of pushing po to working repo! *************"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1038 we migrated the Qiskit metapackage CI to use Github Actions
instead of Travis CI. However, as part of that migration one job was
overlooked and not migrated from Travis to Github Actions, the
translatable string post-merge job which generates the po files and
updates the qiskit-community/qiskit-translations repo which new
translatable strings in the docs. The translation repo hasn't
received string updates since we migrated to github actions because
in #1038 we accidently deleted the job and didn't add an equivalent
to Github Actions. This commit corrects the oversight and adds back
a translatable string job to Github Actions.

### Details and comments