### PR TITLE
Broken image in pypi.org "Project description"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Image](images/qiskit_header.png?raw=true)
+![Image](https://raw.githubusercontent.com/Qiskit/qiskit/master/images/qiskit_header.png)
 
 [![License](https://img.shields.io/github/license/Qiskit/qiskit.svg?)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit/master.svg?)](https://travis-ci.com/Qiskit/qiskit) [![](https://img.shields.io/github/release/Qiskit/qiskit.svg)](https://github.com/Qiskit/qiskit/releases) [![Downloads](https://pepy.tech/badge/qiskit)](https://pypi.org/project/qiskit/) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2562110.svg)](https://doi.org/10.5281/zenodo.2562110)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When the README.md is used by pypi.org as "Project description", the banner on top is broken:

<img width="884" alt="Screen Shot 2020-10-18 at 3 34 17 PM" src="https://user-images.githubusercontent.com/766693/96378035-810ef480-1157-11eb-968b-a6b05c9ac5e7.png">



### Details and comments

This PR uses an absolute path to the image to avoid the broken link.
