### PR TITLE
Remove peakmem benchmarks from the benchmark suite

### DIFF
--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -68,11 +68,6 @@ class PassBenchmarks:
         swap.property_set['layout'] = self.layout
         swap.run(self.dag)
 
-    def peakmem_stochastic_swap(self, _, __):
-        swap = StochasticSwap(self.coupling_map, seed=42)
-        swap.property_set['layout'] = self.layout
-        swap.run(self.dag)
-
     def track_stochastic_swap_depth(self, _, __):
         swap = StochasticSwap(self.coupling_map, seed=42)
         swap.property_set['layout'] = self.layout
@@ -85,11 +80,6 @@ class PassBenchmarks:
 
     # Disable lookahead swap benchmarks due to timeout.
     # def time_lookahead_swap(self, _, __):
-    #     swap = LookaheadSwap(self.coupling_map)
-    #     swap.property_set['layout'] = self.layout
-    #     swap.run(self.dag)
-
-    # def peakmem_lookahead_swap(self, _, __):
     #     swap = LookaheadSwap(self.coupling_map)
     #     swap.property_set['layout'] = self.layout
     #     swap.run(self.dag)
@@ -109,11 +99,6 @@ class PassBenchmarks:
         swap.property_set['layout'] = self.layout
         swap.run(self.dag)
 
-    def peakmem_basic_swap(self, _, __):
-        swap = BasicSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        swap.run(self.dag)
-
     def track_basic_swap_depth(self, _, __):
         swap = BasicSwap(self.coupling_map)
         swap.property_set['layout'] = self.layout
@@ -127,13 +112,7 @@ class PassBenchmarks:
     def time_csp_layout(self, _, __):
         CSPLayout(self.coupling_map, seed=42).run(self.fresh_dag)
 
-    def peakmem_csp_layout(self, _, __):
-        CSPLayout(self.coupling_map, seed=42).run(self.fresh_dag)
-
     def time_dense_layout(self, _, __):
-        DenseLayout(self.coupling_map).run(self.fresh_dag)
-
-    def peakmem_dense_layout(self, _, __):
         DenseLayout(self.coupling_map).run(self.fresh_dag)
 
     def time_layout_2q_distance(self, _, __):
@@ -141,15 +120,7 @@ class PassBenchmarks:
         layout.property_set['layout'] = self.layout
         layout.run(self.dag)
 
-    def peakmem_layout_2q_distance(self, _, __):
-        layout = Layout2qDistance(self.coupling_map)
-        layout.property_set['layout'] = self.layout
-        layout.run(self.dag)
-
     def time_cxdirection(self, _, __):
-        CXDirection(self.coupling_map).run(self.dag)
-
-    def peakmem_cxdirection(self, _, __):
         CXDirection(self.coupling_map).run(self.dag)
 
     def track_cxdirection_depth(self, _, __):
@@ -164,17 +135,7 @@ class PassBenchmarks:
         layout.property_set['layout'] = self.layout
         layout.run(self.dag)
 
-    def peakmem_apply_layout(self, _, __):
-        layout = ApplyLayout()
-        layout.property_set['layout'] = self.layout
-        layout.run(self.dag)
-
     def time_full_ancilla_allocation(self, _, __):
-        ancilla = FullAncillaAllocation(self.coupling_map)
-        ancilla.property_set['layout'] = self.layout
-        ancilla.run(self.fresh_dag)
-
-    def peakmem_full_ancilla_allocation(self, _, __):
         ancilla = FullAncillaAllocation(self.coupling_map)
         ancilla.property_set['layout'] = self.layout
         ancilla.run(self.fresh_dag)
@@ -184,37 +145,17 @@ class PassBenchmarks:
         ancilla.property_set['layout'] = self.layout
         ancilla.run(self.full_ancilla_dag)
 
-    def peakmem_enlarge_with_ancilla(self, _, __):
-        ancilla = EnlargeWithAncilla()
-        ancilla.property_set['layout'] = self.layout
-        ancilla.run(self.full_ancilla_dag)
-
     def time_check_map(self, _, __):
-        CheckMap(self.coupling_map).run(self.dag)
-
-    def peakmem_check_map(self, _, __):
         CheckMap(self.coupling_map).run(self.dag)
 
     def time_check_cx_direction(self, _, __):
         CheckCXDirection(self.coupling_map).run(self.dag)
 
-    def peakmem_check_cx_direction(self, _, __):
-        CheckCXDirection(self.coupling_map).run(self.dag)
-
     def time_trivial_layout(self, _, __):
-        TrivialLayout(self.coupling_map).run(self.fresh_dag)
-
-    def peakmem_trivial_layout(self, _, __):
         TrivialLayout(self.coupling_map).run(self.fresh_dag)
 
     def time_set_layout(self, _, __):
         SetLayout(self.layout).run(self.fresh_dag)
 
-    def peakmem_set_layout(self, _, __):
-        SetLayout(self.layout).run(self.fresh_dag)
-
     def time_noise_adaptive_layout(self, _, __):
-        NoiseAdaptiveLayout(self.backend_props).run(self.fresh_dag)
-
-    def peakmem_noise_adaptive_layout(self, _, __):
         NoiseAdaptiveLayout(self.backend_props).run(self.fresh_dag)

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -44,11 +44,6 @@ class Collect2QPassBenchmarks:
         _pass.property_set['block_list'] = self.block_list
         _pass.run(self.dag)
 
-    def peakmem_consolidate_blocks(self, _, __):
-        _pass = ConsolidateBlocks()
-        _pass.property_set['block_list'] = self.block_list
-        _pass.run(self.dag)
-
     def track_consolidate_blocks_depth(self, _, __):
         _pass = ConsolidateBlocks()
         _pass.property_set['block_list'] = self.block_list
@@ -78,11 +73,6 @@ class CommutativeAnalysisPassBenchmarks:
         _pass.property_set['commutation_set'] = self.commutation_set
         _pass.run(self.dag)
 
-    def peakmem_commutative_cancellation(self, _, __):
-        _pass = CommutativeCancellation()
-        _pass.property_set['commutation_set'] = self.commutation_set
-        _pass.run(self.dag)
-
     def track_commutative_cancellation_depth(self, _, __):
         _pass = CommutativeCancellation()
         _pass.property_set['commutation_set'] = self.commutation_set
@@ -107,9 +97,6 @@ class UnrolledPassBenchmarks:
     def time_optimize_1q(self, _, __):
         Optimize1qGates().run(self.unrolled_dag)
 
-    def peakmem_optimize_1q(self, _, __):
-        Optimize1qGates().run(self.unrolled_dag)
-
     def track_optimize_1q_depth(self, _, __):
         return Optimize1qGates().run(self.unrolled_dag).depth()
 
@@ -131,76 +118,40 @@ class PassBenchmarks:
     def time_unroller(self, _, __):
         Unroller(self.basis_gates).run(self.dag)
 
-    def peakmem_unroller(self, _, __):
-        Unroller(self.basis_gates).run(self.dag)
-
     def track_unroller_depth(self, _, __):
         return Unroller(self.basis_gates).run(self.dag).depth()
 
     def time_depth_pass(self, _, __):
         Depth().run(self.dag)
 
-    def peakmem_depth_pass(self, _, __):
-        Depth().run(self.dag)
-
     def time_size_pass(self, _, __):
-        Size().run(self.dag)
-
-    def peakmem_size_pass(self, _, __):
         Size().run(self.dag)
 
     def time_width_pass(self, _, __):
         Width().run(self.dag)
 
-    def peakmem_width_pass(self, _, __):
-        Width().run(self.dag)
-
     def time_count_ops_pass(self, _, __):
-        CountOps().run(self.dag)
-
-    def peakmem_count_ops_pass(self, _, __):
         CountOps().run(self.dag)
 
     def time_count_ops_longest_path(self, _, __):
         CountOpsLongestPath().run(self.dag)
 
-    def peakmem_count_ops_longest_path(self, _, __):
-        CountOpsLongestPath().run(self.dag)
-
     def time_num_tensor_factors(self, _, __):
-        NumTensorFactors().run(self.dag)
-
-    def peakmem_num_tensor_factors(self, _, __):
         NumTensorFactors().run(self.dag)
 
     def time_resource_optimization(self, _, __):
         ResourceEstimation().run(self.dag)
 
-    def peakmem_resoure_optimization(self, _, __):
-        ResourceEstimation().run(self.dag)
-
     def time_cx_cancellation(self, _, __):
-        CXCancellation().run(self.dag)
-
-    def peakmem_cx_cancellation(self, _, __):
         CXCancellation().run(self.dag)
 
     def time_dag_longest_path(self, _, __):
         DAGLongestPath().run(self.dag)
 
-    def peakmem_dag_longest_path(self, _, __):
-        DAGLongestPath().run(self.dag)
-
     def time_merge_adjacent_barriers(self, _, __):
         MergeAdjacentBarriers().run(self.dag)
 
-    def peakmem_merge_adjacent_barriers(self, _, __):
-        MergeAdjacentBarriers().run(self.dag)
-
     def time_decompose_pass(self, _, __):
-        Decompose().run(self.dag)
-
-    def peakmem_decompose_pass(self, _, __):
         Decompose().run(self.dag)
 
     def track_decompose_depth(self, _, __):
@@ -209,22 +160,13 @@ class PassBenchmarks:
     def time_unroll_3q_or_more(self, _, __):
         Unroll3qOrMore().run(self.dag)
 
-    def peakmem_unroll_3q_or_more(self, _, __):
-        Unroll3qOrMore().run(self.dag)
-
     def track_unroll_3q_or_more_depth(self, _, __):
         return Unroll3qOrMore().run(self.dag).depth()
 
     def time_commutation_analysis(self, _, __):
         CommutationAnalysis().run(self.dag)
 
-    def peakmem_commutation_analysis(self, _, __):
-        CommutationAnalysis().run(self.dag)
-
     def time_remove_reset_in_zero_state(self, _, __):
-        RemoveResetInZeroState().run(self.dag)
-
-    def peakmem_remove_reset_in_zero_state(self, _, __):
         RemoveResetInZeroState().run(self.dag)
 
     def track_remove_reset_in_zero_state(self, _, __):
@@ -233,13 +175,7 @@ class PassBenchmarks:
     def time_collect_2q_blocks(self, _, __):
         Collect2qBlocks().run(self.dag)
 
-    def peakmem_collect_2q_blocks(self, _, __):
-        Collect2qBlocks().run(self.dag)
-
     def time_optimize_swap_before_measure(self, _, __):
-        OptimizeSwapBeforeMeasure().run(self.dag)
-
-    def peakmem_optimize_swap_before_measure(self, _, __):
         OptimizeSwapBeforeMeasure().run(self.dag)
 
     def track_optimize_swap_before_measure_depth(self, _, __):
@@ -248,25 +184,16 @@ class PassBenchmarks:
     def time_barrier_before_final_measurements(self, _, __):
         BarrierBeforeFinalMeasurements().run(self.dag)
 
-    def peakmem_barrier_before_final_measurement(self, _, __):
-        BarrierBeforeFinalMeasurements().run(self.dag)
-
     def track_barrier_before_final_measurement(self, _, __):
         BarrierBeforeFinalMeasurements().run(self.dag).depth()
 
     def time_remove_diagonal_gates_before_measurement(self, _, __):
         RemoveDiagonalGatesBeforeMeasure().run(self.dag)
 
-    def peakmem_remove_diagonal_gates_before_measurement(self, _, __):
-        RemoveDiagonalGatesBeforeMeasure().run(self.dag)
-
     def track_remove_diagonal_gates_before_measurement(self, _, __):
         return RemoveDiagonalGatesBeforeMeasure().run(self.dag).depth()
 
     def time_remove_final_measurements(self, _, __):
-        RemoveFinalMeasurements().run(self.dag)
-
-    def peakmem_remove_final_measurements(self, _, __):
         RemoveFinalMeasurements().run(self.dag)
 
     def track_remove_final_measurements_depth(self, _, __):

--- a/test/benchmarks/ripple_adder.py
+++ b/test/benchmarks/ripple_adder.py
@@ -32,9 +32,6 @@ class RippleAdderConstruction:
     def time_build_ripple_adder(self, size):
         build_ripple_adder_circuit(size)
 
-    def peakmem_build_ripple_adder(self, size):
-        build_ripple_adder_circuit(size)
-
 
 class RippleAdderTranspile:
     params = ([10, 20],
@@ -53,21 +50,11 @@ class RippleAdderTranspile:
         transpile(self.circuit, self.sim_backend,
                   optimization_level=level)
 
-    def peakmem_transpile_simulator_ripple_adder(self, _, level):
-        transpile(self.circuit, self.sim_backend,
-                  optimization_level=level)
-
     def track_depth_transpile_simulator_ripple_adder(self, _, level):
         return transpile(self.circuit, self.sim_backend,
                          optimization_level=level).depth()
 
     def time_transpile_square_grid_ripple_adder(self, _, level):
-        transpile(self.circuit,
-                  coupling_map=self.coupling_map,
-                  basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
-                  optimization_level=level)
-
-    def peakmem_transpile_square_grid_ripple_adder(self, _, level):
         transpile(self.circuit,
                   coupling_map=self.coupling_map,
                   basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],

--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -162,12 +162,6 @@ class TranspilerLevelBenchmarks:
                   seed_transpiler=0,
                   optimization_level=transpiler_level)
 
-    def peakmem_quantum_volume_transpile_50_x_20(self, transpiler_level):
-        transpile(self.qv_50_x_20, basis_gates=self.basis_gates,
-                  coupling_map=self.rochester_coupling_map,
-                  seed_transpiler=0,
-                  optimization_level=transpiler_level)
-
     def track_depth_quantum_volume_transpile_50_x_20(self, transpiler_level):
         return transpile(self.qv_50_x_20, basis_gates=self.basis_gates,
                          coupling_map=self.rochester_coupling_map,
@@ -175,12 +169,6 @@ class TranspilerLevelBenchmarks:
                          optimization_level=transpiler_level).depth()
 
     def time_transpile_from_large_qasm(self, transpiler_level):
-        transpile(self.large_qasm, basis_gates=self.basis_gates,
-                  coupling_map=self.rochester_coupling_map,
-                  seed_transpiler=0,
-                  optimization_level=transpiler_level)
-
-    def peakmem_transpile_from_large_qasm(self, transpiler_level):
         transpile(self.large_qasm, basis_gates=self.basis_gates,
                   coupling_map=self.rochester_coupling_map,
                   seed_transpiler=0,
@@ -197,21 +185,12 @@ class TranspilerLevelBenchmarks:
         transpile(self.large_qasm, self.melbourne, seed_transpiler=0,
                   optimization_level=transpiler_level)
 
-    def peakmem_transpile_from_large_qasm_backend_with_prop(self,
-                                                            transpiler_level):
-        transpile(self.large_qasm, self.melbourne, seed_transpiler=0,
-                  optimization_level=transpiler_level)
-
     def track_depth_transpile_from_large_qasm_backend_with_prop(
             self, transpiler_level):
         return transpile(self.large_qasm, self.melbourne, seed_transpiler=0,
                          optimization_level=transpiler_level).depth()
 
     def time_transpile_qv_14_x_14(self, transpiler_level):
-        transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
-                  optimization_level=transpiler_level)
-
-    def peakmem_transpile_qv_14_x_14(self, transpiler_level):
         transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
                   optimization_level=transpiler_level)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes all the peakmem benchmarks from the benchmark suite.
The peakmem benchmarks have proven to be unreliable in practice and are
prone to inaccurately flag large regressions in the amount of memory
used (see Qiskit/qiskit-terra#4689 and Qiskit/qiskit-terra#5247) which
are unreproduceable and also don't match what running processes on the
benchmark show. This might be an artifact of the asv launch method used,
but either way if we can't rely on the benchmarks to provide a
consistent baseline running benchmarks to measure memory consumption is
a waste of CPU time that could be spent providing wider benchmarking
coverage.

### Details and comments