### PR TITLE
Update python versions in asv conf

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -67,7 +67,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.5", "3.6", "3.7"],
+    "pythons": ["3.6", "3.7", "3.8"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the supported python versions in the asv.conf. Since
the terra 0.16.0 release (qiskit 0.23.0) hasn't support running with 3.5 so
that is removed. Also qiskit has supported python 3.8 since the combined
0.12.0 release. So 3.5 is removed from the list and 3.8 is added (which
is quite overdue).

### Details and comments


