### PR TITLE
Compress docs and tutorials artifacts before upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,14 @@ jobs:
           python -m pip install -r requirements-dev.txt
       - name: Build Docs
         run: tox -edocs -- -j auto
+      - name: Compress Artifacts
+        run: |
+          mkdir artifacts
+          tar -zcvf html_docs.tar.gz docs/_build/html
       - uses: actions/upload-artifact@v2
         with:
           name: html_docs
-          path: docs/_build/html
+          path: artifacts
   tutorials:
     name: tutorials
     runs-on: ubuntu-latest
@@ -83,7 +87,11 @@ jobs:
           set -e
           cd qiskit-tutorials
           sphinx-build -b html . _build/html
+      - name: Compress Artifacts
+        run: |
+          mkdir artifacts
+          tar -zcvf tutorial_docs.tar.gz qiskit-tutorials/_build/html
       - uses: actions/upload-artifact@v2
         with:
           name: tutorial_docs
-          path: qiskit-tutorials/_build/html
+          path: artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           mkdir artifacts
           tar -zcvf html_docs.tar.gz docs/_build/html
+          mv html_docs.tar.gz artifacts/.
       - uses: actions/upload-artifact@v2
         with:
           name: html_docs
@@ -91,6 +92,7 @@ jobs:
         run: |
           mkdir artifacts
           tar -zcvf tutorial_docs.tar.gz qiskit-tutorials/_build/html
+          mv tutorial_docs.tar.gz artifacts/.
       - uses: actions/upload-artifact@v2
         with:
           name: tutorial_docs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit compresses the docs build artifacts before we upload it. The
output from the docs and tutorials jobs are quite large both in space
and number of files. This causes the upload job to bog down and take a
long time while it iterates over each file. By compressing it prior to
upload it should decrease this overhead since there is a single to
upload.

### Details and comments