### PR TITLE
Pin docplex version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,8 @@ jobs:
         run: |
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials
-          pip install -U jupyter sphinx nbsphinx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4'
-          pip install -U .
+          pip install -c constraints.txt -U jupyter sphinx nbsphinx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4'
+          pip install -c constraints.txt -U .
           sudo apt-get install -y pandoc graphviz
       - name: Run tutorials
         run: |

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
 astroid==2.3.3
 pylint==2.4.4
 cryptography==2.5.0
-docplex==2.16.194
+docplex<=2.16

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 astroid==2.3.3
 pylint==2.4.4
 cryptography==2.5.0
+docplex==2.16.194

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
 astroid==2.3.3
 pylint==2.4.4
 cryptography==2.5.0
-docplex==2.16.194
+docplex==2.15.194

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
 astroid==2.3.3
 pylint==2.4.4
 cryptography==2.5.0
-docplex<=2.16
+docplex==2.16.194


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The latest docplex version which was released recently breaks the aqua
quadratic_program module. This commit pins the docplex version to
unblock CI, while we wait for the in-progress aqua PR Qiskit/qiskit-aqua#1420
fixing this to be included in a release.

### Details and comments