### PR TITLE
Bump cell timeout in the tutorials CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,8 @@ jobs:
           set -e
           cd qiskit-tutorials
           sphinx-build -b html . _build/html
+        env:
+          QISKIT_CELL_TIMEOUT: 300
       - name: Compress Artifacts
         run: |
           mkdir artifacts


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The 07_asian_barrier_spread_pricing tutorial is quite slow and often
times out in CI because running the simulation takes very close to 3
minutes in the fastest case. But, the performance of the CI nodes is
quite variable since they run on virtual machines in azure's public
cloud. So many jobs fail randomly because of timeouts on that notebook.
In Qiskit/qiskit-tutorial#1091 we added an env var to adjust the per
cell timeout for CI jobs. This commit leverages that env var in an
attempt to fix the timeout issues by bumping the timeout to 5 min which
should hopefully give us a healthy margin for slow CI nodes. Especially
since the upstream tutorials repo CI is still holding incoming PRs to 3
mins per cell.


### Details and comments