### PR TITLE
Fix random_circuit_hex benchmarks

### DIFF
--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -17,13 +17,7 @@
 
 import copy
 
-try:
-    from qiskit.quantum_info.synthesis import euler_angles_1q
-except ImportError:
-    try:
-        from qiskit.mapper.compiling import euler_angles_1q
-    except ImportError:
-        from qiskit.mapper._compiling import euler_angles_1q
+from qiskit.quantum_info.synthesis import OneQubitEulerDecomposer
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
 from qiskit import BasicAer
 try:
@@ -50,6 +44,7 @@ def make_circuit_ring(nq, depth, seed):
     # Create a Quantum Circuit
     qc = QuantumCircuit(q, c)
     offset = 1
+    decomposer = OneQubitEulerDecomposer()
     # initial round of random single-qubit unitaries
     for i in range(nq):
         qc.h(q[i])
@@ -63,7 +58,7 @@ def make_circuit_ring(nq, depth, seed):
             else:
                 u = random_unitary_matrix(2)
 
-            angles = euler_angles_1q(u)
+            angles = decomposer.angles(u)
             qc.u3(angles[0], angles[1], angles[2], q[i])
 
     # insert the final measurements


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#5439 a bunch of deprecated quantum_info module
methods were removed from terra. This included one that the
random_circuit_hex benchmark module was relying on which has been
causing benchmark failure since Qiskit/qiskit-terra#5439 merged. This
commit updates the benchmarks to use the new methods to fix the
benchmarks.

### Details and comments


