### PR TITLE
Pin scipy version in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,3 +2,4 @@ astroid==2.3.3
 pylint==2.4.4
 cryptography==2.5.0
 docplex==2.15.194
+scipy==1.5.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent release of scipy 1.6.0 is causing the qsvm tutorials to fail
(see Qiskit/qiskit-aqua#1498 for more details). This is blocking the
docs deploy CI job because it runs the tutorials (as well as the likely
the tutorials job too) and preventing us from uploading new versions of
the built documentation. This commit pins the scipy version to a known
working version (1.5.4) to unblock CI until we have a fix for the
tutorial failure with scipy 1.6.0.

### Details and comments