### PR TITLE
Fix the Pulse schedule construction benchmarks

### DIFF
--- a/test/benchmarks/pulse/schedule_construction.py
+++ b/test/benchmarks/pulse/schedule_construction.py
@@ -16,7 +16,8 @@
 # pylint: disable=attribute-defined-outside-init
 
 import numpy as np
-from qiskit.pulse import Schedule, Gaussian, DriveChannel, SamplePulse, Play
+
+from qiskit.pulse import Schedule, Gaussian, DriveChannel, Play, Waveform
 
 
 def build_sample_pulse_schedule(number_of_unique_pulses, number_of_channels):
@@ -24,7 +25,7 @@ def build_sample_pulse_schedule(number_of_unique_pulses, number_of_channels):
     sched = Schedule()
     for _ in range(number_of_unique_pulses):
         for channel in range(number_of_channels):
-            sched.append(Play(SamplePulse(rng.random(50)),
+            sched.append(Play(Waveform(rng.random(50)),
                               DriveChannel(channel)))
     return sched
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The Pulse schedule construction benchmarks were using the previously
deprecated and now removed SamplePulse class as the pulse to add to a
schedule. This has been failing in benchmark runs since that class was
removed. This commit fixes the failure by using the replacement class
Waveform. This will break compatibility with old versions of terra from
before waveform existed, however since we're unlikely to run a backfill
job for historical data this is an ok tradeoff.

### Details and comments

Fixes #1146 