### PR TITLE
Cleanup release notes for 0.23.3

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -140,16 +140,6 @@ New Features
   Aer using Python 3.9 without building from source.
 
 
-.. _Release Notes_Aer_0.7.3_Deprecation Notes:
-
-Deprecation Notes
------------------
-
-- Python 3.6 support has been deprecated and will be removed in a future
-  release. When support is removed you will need to upgrade the Python
-  version you're using to Python 3.7 or above.
-
-
 .. _Release Notes_Aer_0.7.3_Bug Fixes:
 
 Bug Fixes
@@ -166,7 +156,7 @@ Bug Fixes
 
 - Fixes a bug that resulted in `c_if` not working when the
   width of the conditional register was greater than 64. See
-  `#1077 <https://github.com/Qiskit/qiskit-aer/issues/1077>`.
+  `#1077 <https://github.com/Qiskit/qiskit-aer/issues/1077>`__.
 
 - Fixes bug in
   :meth:`~qiskit.providers.aer.noise.NoiseModel.from_backend` and


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The release notes added for 0.23.3 had some small issues. First the
python 3.6 deprecation not in Aer was incorrectly backported. The
deprecation isn't supposed to start until the 0.8 release (which is when
a warning will be emitted). The second issue was a syntax error in a link.
This commit corrects these issues.

### Details and comments