### PR TITLE
Mark versionutils extension as not parallel_read_safe

### DIFF
--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -39,7 +39,7 @@ def setup(app):
     app.add_config_value('content_prefix', '', '')
     app.add_config_value('translations', True, 'html')
     app.add_directive('version-history', _VersionHistory)
-    return {'parallel_read_safe': True}
+    return {'parallel_read_safe': True, 'version': '1.0.0'}
 
 def _extend_html_context(app, config):
     context = config.html_context

--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -39,6 +39,7 @@ def setup(app):
     app.add_config_value('content_prefix', '', '')
     app.add_config_value('translations', True, 'html')
     app.add_directive('version-history', _VersionHistory)
+    return {'parallel_read_safe': True}
 
 def _extend_html_context(app, config):
     context = config.html_context

--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -39,7 +39,7 @@ def setup(app):
     app.add_config_value('content_prefix', '', '')
     app.add_config_value('translations', True, 'html')
     app.add_directive('version-history', _VersionHistory)
-    return {'parallel_read_safe': True, 'version': '1.0.0'}
+    return {'parallel_read_safe': False, 'version': '1.0.0'}
 
 def _extend_html_context(app, config):
     context = config.html_context


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The versionutils sphinx extension we use during the combined
documentation is raising a warning on each sphinx build about it not
specifying a parallel_read_safe option. This warning while not fatal has
a potential future issue if/when we're able to set `-W` during builds this
would be a blocker. This commit returns the `parallel_read_safe` option
as False since it turns out the extension is not parallel read safe.

### Details and comments


