### PR TITLE
Exclude other documentation builds from rclone sync

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -29,4 +29,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress --exclude 'locale/**' ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation
+rclone sync --progress ---exclude-from ./tools/other-builds.txt ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation

--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -1,0 +1,8 @@
+locale/**
+metal/**
+optimization/**
+machine-learning/**
+partners/**
+nature/**
+finance/**
+experiments/**


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the near future there will be several documentation builds for qiskit
projects hosted off the https://qiskit.org/documentation page that will
be self contained in the project repository and uploaded directly by the
project. To avoid the main qiskit doc uploads for deleting that content
this commit adds an exclude list for all those other builds. This
includes the existing locale build directory for translated documentation
which we were already excluding.


### Details and comments