### PR TITLE
Remove benchmarks that measure BasicAer as transpile target

### DIFF
--- a/test/benchmarks/isometry.py
+++ b/test/benchmarks/isometry.py
@@ -36,17 +36,6 @@ class IsometryTranspileBench:
         qc.iso(iso, q[:m], q[m:])
         self.circuit = qc
 
-    def time_simulator_transpile(self, *unused):
-        transpile(self.circuit, basis_gates=['u1', 'u3', 'u2', 'cx'],
-                  seed_transpiler=0)
-
-    def track_cnot_counts(self, *unused):
-        circuit = transpile(self.circuit, basis_gates=['u1', 'u3', 'u2', 'cx'],
-                            seed_transpiler=0)
-        counts = circuit.count_ops()
-        cnot_count = counts.get('cx', 0)
-        return cnot_count
-
     def track_cnot_counts_after_mapping_to_ibmq_16_melbourne(self, *unused):
         coupling = [[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4],
                     [5, 6], [5, 9], [6, 8], [7, 8], [9, 8], [9, 10],

--- a/test/benchmarks/qft.py
+++ b/test/benchmarks/qft.py
@@ -18,7 +18,6 @@
 import math
 
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit import BasicAer
 try:
     from qiskit.compiler import transpile
 except ImportError:
@@ -46,10 +45,6 @@ class QftTranspileBench:
     def setup(self, n):
         qr = QuantumRegister(n)
         self.circuit = build_model_circuit(qr)
-        self.sim_backend = BasicAer.get_backend('qasm_simulator')
-
-    def time_simulator_transpile(self, _):
-        transpile(self.circuit, self.sim_backend)
 
     def time_ibmq_backend_transpile(self, _):
         # Run with ibmq_16_melbourne configuration

--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -19,7 +19,7 @@ import copy
 
 from qiskit.quantum_info.synthesis import OneQubitEulerDecomposer
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
-from qiskit import BasicAer
+
 try:
     from qiskit.compiler import transpile
     TRANSPILER_SEED_KEYWORD = 'seed_transpiler'
@@ -77,15 +77,6 @@ class BenchRandomCircuitHex:
         depth = 2 * n
         self.seed = 0
         self.circuit = make_circuit_ring(n, depth, self.seed)[0]
-        self.sim_backend = BasicAer.get_backend('qasm_simulator')
-
-    def time_simulator_transpile(self, _):
-        transpile(self.circuit, self.sim_backend,
-                  **{TRANSPILER_SEED_KEYWORD: self.seed})
-
-    def track_depth_simulator_transpile(self, _):
-        return transpile(self.circuit, self.sim_backend,
-                         **{TRANSPILER_SEED_KEYWORD: self.seed}).depth()
 
     def time_ibmq_backend_transpile(self, _):
         # Run with ibmq_16_melbourne configuration

--- a/test/benchmarks/randomized_benchmarking.py
+++ b/test/benchmarks/randomized_benchmarking.py
@@ -75,6 +75,7 @@ class RandomizedBenchmarkingBenchmark:
                                          length_vector=length_vector,
                                          rb_pattern=rb_pattern,
                                          seed=self.seed)
+
     def teardown(self, _):
         os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
 

--- a/test/benchmarks/randomized_benchmarking.py
+++ b/test/benchmarks/randomized_benchmarking.py
@@ -20,7 +20,6 @@
 import os
 import numpy as np
 import qiskit.ignis.verification.randomized_benchmarking as rb
-from qiskit.providers.basicaer import QasmSimulatorPy
 
 try:
     from qiskit.compiler import transpile
@@ -76,19 +75,8 @@ class RandomizedBenchmarkingBenchmark:
                                          length_vector=length_vector,
                                          rb_pattern=rb_pattern,
                                          seed=self.seed)
-        self.sim_backend = QasmSimulatorPy()
-
     def teardown(self, _):
         os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
-
-    def time_simulator_transpile(self, __):
-        transpile(self.circuits, self.sim_backend,
-                  **{TRANSPILER_SEED_KEYWORD: self.seed})
-
-    def time_simulator_transpile_single_thread(self, __):
-        os.environ['QISKIT_IN_PARALLEL'] = 'TRUE'
-        transpile(self.circuits, self.sim_backend,
-                  **{TRANSPILER_SEED_KEYWORD: self.seed})
 
     def time_ibmq_backend_transpile(self, __):
         # Run with ibmq_16_melbourne configuration

--- a/test/benchmarks/ripple_adder.py
+++ b/test/benchmarks/ripple_adder.py
@@ -18,8 +18,6 @@
 from qiskit import transpile
 from qiskit.transpiler import CouplingMap
 
-from qiskit.providers.basicaer import QasmSimulatorPy
-
 from .utils import build_ripple_adder_circuit
 
 
@@ -43,16 +41,7 @@ class RippleAdderTranspile:
     def setup(self, size, _):
         edge_len = int((2*size + 2)**0.5)+1
         self.coupling_map = CouplingMap.from_grid(edge_len, edge_len)
-        self.sim_backend = QasmSimulatorPy()
         self.circuit = build_ripple_adder_circuit(size)
-
-    def time_transpile_simulator_ripple_adder(self, _, level):
-        transpile(self.circuit, self.sim_backend,
-                  optimization_level=level)
-
-    def track_depth_transpile_simulator_ripple_adder(self, _, level):
-        return transpile(self.circuit, self.sim_backend,
-                         optimization_level=level).depth()
 
     def time_transpile_square_grid_ripple_adder(self, _, level):
         transpile(self.circuit,

--- a/test/benchmarks/transpiler_benchmarks.py
+++ b/test/benchmarks/transpiler_benchmarks.py
@@ -23,107 +23,56 @@ import qiskit
 class TranspilerBenchSuite:
 
     def _build_cx_circuit(self):
-        if self.local_qasm_simulator is None:
-            qp = qiskit.QuantumProgram()
-            cx_register = qp.create_quantum_register('qr', 2)
-            cx_circuit = qp.create_circuit("cx_circuit", [cx_register])
-            cx_circuit.h(cx_register[0])
-            cx_circuit.h(cx_register[0])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            return qp
-        if self.local_qasm_simulator is not None:
-            cx_register = qiskit.QuantumRegister(2)
-            cx_circuit = qiskit.QuantumCircuit(cx_register)
-            cx_circuit.h(cx_register[0])
-            cx_circuit.h(cx_register[0])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            cx_circuit.cx(cx_register[0], cx_register[1])
-            return cx_circuit
-        return None
+        cx_register = qiskit.QuantumRegister(2)
+        cx_circuit = qiskit.QuantumCircuit(cx_register)
+        cx_circuit.h(cx_register[0])
+        cx_circuit.h(cx_register[0])
+        cx_circuit.cx(cx_register[0], cx_register[1])
+        cx_circuit.cx(cx_register[0], cx_register[1])
+        cx_circuit.cx(cx_register[0], cx_register[1])
+        cx_circuit.cx(cx_register[0], cx_register[1])
+        return cx_circuit
 
     def _build_single_gate_circuit(self):
-        if self.local_qasm_simulator is None:
-            qp = qiskit.QuantumProgram()
-            single_register = qp.create_quantum_register('qr', 1)
-            single_gate_circuit = qp.create_circuit('single_gate',
-                                                    [single_register])
-            single_gate_circuit.h(single_register[0])
-            return qp
-        if self.local_qasm_simulator is not None:
-            single_register = qiskit.QuantumRegister(1)
-            single_gate_circuit = qiskit.QuantumCircuit(single_register)
-            single_gate_circuit.h(single_register[0])
-            return single_gate_circuit
-        return None
+        single_register = qiskit.QuantumRegister(1)
+        single_gate_circuit = qiskit.QuantumCircuit(single_register)
+        single_gate_circuit.h(single_register[0])
+        return single_gate_circuit
 
     def setup(self):
-        version_parts = qiskit.__version__.split('.')
-
-        if version_parts[0] == '0' and int(version_parts[1]) < 5:
-            self.local_qasm_simulator = None
-        elif hasattr(qiskit, 'BasicAer'):
-            self.local_qasm_simulator = qiskit.BasicAer.get_backend(
-                'qasm_simulator')
-        elif hasattr(qiskit, 'get_backend'):
-            self.local_qasm_simulator = qiskit.get_backend(
-                'local_qasm_simulator')
-        else:
-            self.local_qasm_simulator = qiskit.BasicAer.get_backend(
-                "qasm_simulator")
-        self.has_compile = False
-        if hasattr(qiskit, 'compile'):
-            self.has_compile = True
         self.single_gate_circuit = self._build_single_gate_circuit()
         self.cx_circuit = self._build_cx_circuit()
         self.qasm_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), 'qasm'))
         large_qasm_path = os.path.join(self.qasm_path, 'test_eoh_qasm.qasm')
+        self.large_qasm = qiskit.QuantumCircuit.from_qasm_file(large_qasm_path)
+        self.coupling_map = [
+            [0, 1], [1, 0], [1, 2], [1, 4], [2, 1], [2, 3], [3, 2], [3, 5],
+            [4, 1], [4, 7], [5, 3], [5, 8], [6, 7], [7, 4], [7, 6], [7, 10],
+            [8, 5], [8, 9], [8, 11], [9, 8], [10, 7], [10, 12], [11, 8],
+            [11, 14], [12, 10], [12, 13], [12, 15], [13, 12], [13, 14],
+            [14, 11], [14, 13], [14, 16], [15, 12], [15, 18], [16, 14],
+            [16, 19], [17, 18], [18, 15], [18, 17], [18, 21], [19, 16],
+            [19, 20], [19, 22], [20, 19], [21, 18], [21, 23], [22, 19],
+            [22, 25], [23, 21], [23, 24], [24, 23], [24, 25], [25, 22],
+            [25, 24], [25, 26], [26, 25]]
+        self.basis = ['id', 'rz', 'sx', 'x', 'cx', 'reset']
 
-        if hasattr(qiskit, 'load_qasm_file'):
-            self.large_qasm = qiskit.load_qasm_file(large_qasm_path)
-        elif version_parts[0] == '0' and int(version_parts[1]) < 5:
-            self.large_qasm = qiskit.QuantumProgram()
-            self.large_qasm.load_qasm_file(large_qasm_path,
-                                           name='large_qasm')
-        else:
-            self.large_qasm = qiskit.QuantumCircuit.from_qasm_file(
-                large_qasm_path)
 
-    def time_single_gate_transpile(self):
-        if self.local_qasm_simulator is None:
-            self.single_gate_circuit.compile('single_gate')
-        else:
-            if self.has_compile:
-                qiskit.compile(self.single_gate_circuit,
-                               self.local_qasm_simulator)
-            else:
-                circ = qiskit.compiler.transpile(self.single_gate_circuit,
-                                                 self.local_qasm_simulator)
-                qiskit.compiler.assemble(circ, self.local_qasm_simulator)
+    def time_single_gate_compile(self):
+        circ = qiskit.compiler.transpile(self.single_gate_circuit,
+                                         coupling_map=self.coupling_map,
+                                         basis_gates=self.basis)
+        qiskit.compiler.assemble(circ)
 
-    def time_cx_transpile(self):
-        if self.local_qasm_simulator is None:
-            self.cx_circuit.compile('cx_circuit')
-        else:
-            if self.has_compile:
-                qiskit.compile(self.cx_circuit, self.local_qasm_simulator)
-            else:
-                circ = qiskit.compiler.transpile(self.cx_circuit,
-                                                 self.local_qasm_simulator)
-                qiskit.compiler.assemble(circ, self.local_qasm_simulator)
+    def time_cx_compile(self):
+        circ = qiskit.compiler.transpile(self.cx_circuit,
+                                         coupling_map=self.coupling_map,
+                                         basis_gates=self.basis)
+        qiskit.compiler.assemble(circ)
 
-    def time_transpile_from_large_qasm(self):
-        if self.local_qasm_simulator is None:
-            self.large_qasm.compile('large_qasm')
-        else:
-            if self.has_compile:
-                qiskit.compile(self.large_qasm, self.local_qasm_simulator)
-            else:
-                circ = qiskit.compiler.transpile(self.large_qasm,
-                                                 self.local_qasm_simulator)
-                qiskit.compiler.assemble(circ, self.local_qasm_simulator)
+    def time_compile_from_large_qasm(self):
+        circ = qiskit.compiler.transpile(self.large_qasm,
+                                         coupling_map=self.coupling_map,
+                                         basis_gates=self.basis)
+        qiskit.compiler.assemble(circ)

--- a/test/benchmarks/transpiler_benchmarks.py
+++ b/test/benchmarks/transpiler_benchmarks.py
@@ -58,7 +58,6 @@ class TranspilerBenchSuite:
             [25, 24], [25, 26], [26, 25]]
         self.basis = ['id', 'rz', 'sx', 'x', 'cx', 'reset']
 
-
     def time_single_gate_compile(self):
         circ = qiskit.compiler.transpile(self.single_gate_circuit,
                                          coupling_map=self.coupling_map,


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commmit removes all the benchmarks which were using the basic aer
simulator as a target for transpilation. These benchmarks were
originally added in an attempt to show the overhead of using routing and
layout in a transpile but never did a good job of this. We have better
microbenchmarks now of each individual transpiler pass and the basic aer
target isn't a realistic use case for anything anymore. By removing
these duplicate benchmarks we get back some of our time budget that we
can use for adding new benchmarks.

There are 2 benchmarks which aren't updated to remove the basic aer
usage. The first is the quantum_volume module which is addressed in
PR #1185 as part of a larger refactor of that benchmark and the state
tomography benchmarks which are are actually running a simulation in
basic aer and its sill necessary there.


### Details and comments


