### PR TITLE
Add benchmarks using Qiskit aer as a target

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -27,12 +27,14 @@
         "python -mpip install seaborn",
         "python -mpip install pygments",
         "python -mpip install {wheel_file}",
-        "python -mpip install -U qiskit-ignis==0.2.0",
+        "python -mpip install -U qiskit-ignis==0.5.2",
+        "python -m pip install -U qiskit-aer==0.7.6",
         "python -mpip install -U python-constraint"
       ],
     "uninstall_command": [
         "return-code=any python -mpip uninstall -y {project}",
-        "return-code=any python -mpip uninstall -y qiskit-ignis"
+        "return-code=any python -mpip uninstall -y qiskit-ignis",
+        "return-code=any python -mpip uninstall -u qiskit-aer"
     ],
     "build_command": [
         "pip install -U Cython",

--- a/test/benchmarks/randomized_benchmarking.py
+++ b/test/benchmarks/randomized_benchmarking.py
@@ -21,6 +21,8 @@ import os
 import numpy as np
 import qiskit.ignis.verification.randomized_benchmarking as rb
 
+from qiskit import Aer
+
 try:
     from qiskit.compiler import transpile
     TRANSPILER_SEED_KEYWORD = 'seed_transpiler'
@@ -64,13 +66,14 @@ class RandomizedBenchmarkingBenchmark:
     # parameters for RB (1&2 qubits):
     params = ([[[0]], [[0, 1]], [[0, 2], [1]]],)
     param_names = ['rb_pattern']
-    version = '0.2.0'
+    version = '0.5.2_0.7.6'
     timeout = 600
 
     def setup(self, rb_pattern):
         length_vector = np.arange(1, 200, 4)
         nseeds = 1
         self.seed = 10
+        self.aer_backend = Aer.get_backend('qasm_simulator')
         self.circuits = build_rb_circuit(nseeds=nseeds,
                                          length_vector=length_vector,
                                          rb_pattern=rb_pattern,
@@ -103,4 +106,13 @@ class RandomizedBenchmarkingBenchmark:
         transpile(self.circuits,
                   basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
                   coupling_map=coupling_map,
+                  **{TRANSPILER_SEED_KEYWORD: self.seed})
+
+    def time_aer_backend_transpile_single_thread(self, __):
+        os.environ['QISKIT_IN_PARALLEL'] = 'TRUE'
+        transpile(self.circuits, backend=self.aer_backend,
+                  **{TRANSPILER_SEED_KEYWORD: self.seed})
+
+    def time_aer_backend_transpile(self, __):
+        transpile(self.circuits, backend=self.aer_backend,
                   **{TRANSPILER_SEED_KEYWORD: self.seed})

--- a/test/benchmarks/state_tomography.py
+++ b/test/benchmarks/state_tomography.py
@@ -24,12 +24,12 @@ from qiskit.quantum_info import state_fidelity
 class StateTomographyBench:
     params = [2, 3, 4, 5]
     param_names = ['n_qubits']
-    version = '0.2.0'
+    version = '0.5.0_0.7.6'
     timeout = 120.0
 
     def setup(self, _):
-        self.sv_backend = qiskit.BasicAer.get_backend('statevector_simulator')
-        self.qasm_backend = qiskit.BasicAer.get_backend('qasm_simulator')
+        self.sv_backend = qiskit.Aer.get_backend('statevector_simulator')
+        self.qasm_backend = qiskit.Aer.get_backend('qasm_simulator')
 
     def time_state_tomography_bell(self, n_qubits):
         qr = qiskit.QuantumRegister(2)

--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -19,6 +19,7 @@ import os
 
 from qiskit.compiler import transpile
 from qiskit import QuantumCircuit
+from qiskit import Aer
 
 from .backends.fake_melbourne import FakeMelbourne
 from .utils import build_qv_model_circuit
@@ -155,6 +156,7 @@ class TranspilerLevelBenchmarks:
         large_qasm_path = os.path.join(self.qasm_path, 'test_eoh_qasm.qasm')
         self.large_qasm = QuantumCircuit.from_qasm_file(large_qasm_path)
         self.melbourne = FakeMelbourne()
+        self.aer_backend = Aer.get_backend('qasm_simulator')
 
     def time_quantum_volume_transpile_50_x_20(self, transpiler_level):
         transpile(self.qv_50_x_20, basis_gates=self.basis_gates,
@@ -192,6 +194,10 @@ class TranspilerLevelBenchmarks:
 
     def time_transpile_qv_14_x_14(self, transpiler_level):
         transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
+                  optimization_level=transpiler_level)
+
+    def time_transpile_aer_qv_14_x_14(self, transpiler_level):
+        transpile(self.qv_14_x_14, self.aer_backend, seed_transpiler=0,
                   optimization_level=transpiler_level)
 
     def track_depth_transpile_qv_14_x_14(self, transpiler_level):

--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -156,7 +156,6 @@ class TranspilerLevelBenchmarks:
         large_qasm_path = os.path.join(self.qasm_path, 'test_eoh_qasm.qasm')
         self.large_qasm = QuantumCircuit.from_qasm_file(large_qasm_path)
         self.melbourne = FakeMelbourne()
-        self.aer_backend = Aer.get_backend('qasm_simulator')
 
     def time_quantum_volume_transpile_50_x_20(self, transpiler_level):
         transpile(self.qv_50_x_20, basis_gates=self.basis_gates,
@@ -196,10 +195,20 @@ class TranspilerLevelBenchmarks:
         transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
                   optimization_level=transpiler_level)
 
-    def time_transpile_aer_qv_14_x_14(self, transpiler_level):
-        transpile(self.qv_14_x_14, self.aer_backend, seed_transpiler=0,
-                  optimization_level=transpiler_level)
-
     def track_depth_transpile_qv_14_x_14(self, transpiler_level):
         return transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
                          optimization_level=transpiler_level).depth()
+
+
+class TranspilerLevelBenchmarksAer:
+    params = [0, 1, 2, 3]
+    param_names = ['transpiler optimization level']
+    timeout = 600
+
+    def setup(self, _):
+        self.qv_14_x_14 = build_qv_model_circuit(14, 14, 0)
+        self.aer_backend = Aer.get_backend('qasm_simulator')
+
+    def time_transpile_aer_qv_14_x_14(self, transpiler_level):
+        transpile(self.qv_14_x_14, self.aer_backend, seed_transpiler=0,
+                  optimization_level=transpiler_level)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In a follow up to #1186 where we removed all the benchmarks using
BasicAer as a compilation target this commit adds some new benchmarks
that use qiskit-aer as a compilation target. Mainly a single qv
circuit (at all 4 optimization levels) and randomized benchmarking (
both single process and parallel). The state tomography benchmarks were
also updated to use aer instead of basic aer, however those benchmarks
also run a simulation so it's more than just a compilation target
difference. This use of aer is done using a pinned version for stability
in the results when we change the aer version the benchmarks using it
will have to be updated too so we know the results are associated with
a single aer version.

Since we had to invalidate the results/bump the version of the rb
benchmarks this was a good opportunity to update the ignis version to
the latest release (which has a similar pinned version arrangement).

### Details and comments


