### PR TITLE
Cap tweedledum

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ seaborn>=0.9.0
 nbsphinx
 cvxpy<1.1.0
 pyscf<1.7.4
-tweedledum
+tweedledum<1.0.0


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of tweedledum 1.0.0 the docs builds have started
to fail. This is because the released versions of qiskit-terra (0.16.x)
are incompatible with that new tweedledum release. The next terra
release will fix compatibility (and bump the minimum version), but until
terra is released this commit caps the tweedledum version.

### Details and comments

Fixes #1202