### PR TITLE
Add cplex to docs builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ extras =
 deps =
   -r requirements-dev.txt
   sphinx-intl
+  cplex
 commands =
   sphinx-build -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The aqua migration guide that documents how to migrate from using aqua
to the new application packages and terra instead is a jupyter notebook
and requires cplex to execute it. For the publish docs job we run the
notebooks to ensure a consistent output in the cells, but were not
installing cplex. This is causing the docs publish jobs to fail when it
tries to execute the migration notebook because the dependency is
missing. This commit fixes this by just adding cplex to the docs job tox
venv so that it's installed. We should remove this when aqua goes eol
and we no longer need to provide a migration guide.

### Details and comments