### PR TITLE
Fixed example code in release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -251,12 +251,12 @@ New Features
 
     backend = BasicAer.get_backend('qasm_simulator')
 
-    qc = QuantumCircuit(2)
-    qc.h(0)
-    qc.cx(0, 1)
-    qc.measure_all()
+    circuit = QuantumCircuit(2)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.measure_all()
 
-    tqc = transpile(qc, backend)
+    tqc = transpile(circuit, backend)
     result = backend.run(tqc, shots=4096).result()
 
 - The :class:`~qiskit.transpiler.passes.CommutativeCancellation` transpiler

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -251,12 +251,12 @@ New Features
 
     backend = BasicAer.get_backend('qasm_simulator')
 
-    circuit = QuantumCircuit(2)
+    qc = QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
     qc.measure_all()
 
-    tqc = transpile(circuit, backend)
+    tqc = transpile(qc, backend)
     result = backend.run(tqc, shots=4096).result()
 
 - The :class:`~qiskit.transpiler.passes.CommutativeCancellation` transpiler


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixed variable names in code example in the release notes.  `circuit` was defined as a `QuantumCircuit` object but operations were done on `qc` instead, which was never defined. This PR fixes that.


