### PR TITLE
Pin docutils for docs builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         encrypted_rclone_key: ${{ secrets.encrypted_rclone_key }}
         encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
-#        QISKIT_DOCS_BUILD_TUTORIALS: 'always'
+        QISKIT_DOCS_BUILD_TUTORIALS: 'always'
       run: |
         tools/deploy_documentation.sh
   deploy-translatable-strings:

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,4 +4,4 @@ cryptography==2.5.0
 docplex==2.15.194
 scipy==1.5.4
 decorator==4.4.2
-Sphinx==3.3
+docutils==0.16


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent release of docutils 0.17 has started to break the tutorials
output when we execute the notebooks. To workaround this we previously
disabled executing the notebooks for the publish job in #1225. However,
manually testing shows that it was the docutils release and this commit
reverts #1225 and pins docutils to unbreak the build.

### Details and comments