### PR TITLE
Add additional pages to frontmatter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,8 @@ Interested in quantum hardware design?
   :maxdepth: 2
   :hidden:
 
+  qc_intro
+  intro_tutorial1
   release_notes
   contributing_to_qiskit
   configuration

--- a/docs/intro_tutorial1.rst
+++ b/docs/intro_tutorial1.rst
@@ -1,8 +1,6 @@
-:orphan:
-
-===========================
-Getting Started with Qiskit
-===========================
+======================
+Introduction to Qiskit
+======================
 
 When using Qiskit an user workflow nominally consists of
 following four high-level steps:

--- a/docs/qc_intro.rst
+++ b/docs/qc_intro.rst
@@ -1,4 +1,3 @@
-:orphan:
 
 .. figure:: images/qiskit_nutshell.png
    :scale: 50 %


### PR DESCRIPTION
Puts the intro to QC and intro to Qiskit in the frontmatter (they are still accessible via in content links as well).

