### PR TITLE
Update asv configuration

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -42,7 +42,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["master"], // for git
+    "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
@@ -67,7 +67,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.6", "3.7", "3.8"],
+    "pythons": ["3.6", "3.7", "3.8", "3.9"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The asv configuration file was a bit out of date and we actually haven't
been running benchmarks since last week because of this. The
qiskit-terra repository changed the default branch from master to main.
This means when we go to run benchmarks there are no new commits to run
because the asv configuration was setup to track the "master" branch.
This commit fixes this and also updates the python versions to include
python 3.9 which is supported and we should enable running benchmarks
with 3.9 too.

### Details and comments


