### PR TITLE
DOC: fixed some typos

### DIFF
--- a/docs/intro_tutorial1.rst
+++ b/docs/intro_tutorial1.rst
@@ -2,7 +2,7 @@
 Introduction to Qiskit
 ======================
 
-When using Qiskit an user workflow nominally consists of
+When using Qiskit a user workflow nominally consists of
 following four high-level steps:
 
 - **Build**: Design a quantum circuit(s) that represents the problem you are

--- a/docs/qc_intro.rst
+++ b/docs/qc_intro.rst
@@ -60,7 +60,7 @@ integer of :math:`\pi`).
 As shown above, when the phase difference is close to an odd multiple of :math:`\pi`,
 the superposition of the two waves results in interference, and an output that is
 significantly reduced compared to the original.  The result is the signal of interest
-unincumbered by noise. Although this processing is done by digital circuits, the amplitude
+unencumbered by noise. Although this processing is done by digital circuits, the amplitude
 and phase are continuous variables that can never be matched perfectly, resulting in
 incomplete correction.
 


### PR DESCRIPTION
1. unincumbered -> unencumbered (qc_intro.rst)
2. an user -> a user (intro_tutorial1.rst)

(Just that.)