### PR TITLE
Add retworkx to excluded paths for docs upload

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -6,3 +6,4 @@ partners/**
 nature/**
 finance/**
 experiments/**
+retworkx/**


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The retworkx project will soon be moving it's documentation from
https://retworkx.readthedocs.io to qiskit.org/documentation/retworkx.
However when this migration happens the sync run by the main docs build
this would delete the uploaded documentation. This commit adds the
retworkx path to the exclude list to preserve the retworkx documentation
on upload.

### Details and comments