### PR TITLE
Add support for stable versions of documentation

### DIFF
--- a/.github/workflows/docs_tag.yml
+++ b/.github/workflows/docs_tag.yml
@@ -1,4 +1,4 @@
-name: Docs Publish
+name: Stable Docs Publish
 on:
   push:
     tags:

--- a/.github/workflows/docs_tag.yml
+++ b/.github/workflows/docs_tag.yml
@@ -1,0 +1,29 @@
+name: Docs Publish
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U virtualenv setuptools wheel tox
+        sudo apt-get install graphviz pandoc
+    - name: Build and publish
+      env:
+        encrypted_rclone_key: ${{ secrets.encrypted_rclone_key }}
+        encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
+        QISKIT_DOCS_BUILD_TUTORIALS: 'always'
+      run: |
+        tools/deploy_documentation_tag.sh

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -15,7 +15,7 @@
     <dl>
       <dt>Previous Releases</dt>
       {% for version in version_list %}
-        <dd><a class="version" href="/documentation/stable/{{ version }}">{{ version }}</a></dd>
+        <dd><a class="version" href="/documentation/stable/{{ version }}/index.html">{{ version }}</a></dd>
       {% endfor %}
     </dl>
   </div>

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -15,7 +15,7 @@
     <dl>
       <dt>Previous Releases</dt>
       {% for version in version_list %}
-        <dd><a class="version" href"/documentation/stable/{{ version }}">{{ version }}</a></dd>
+        <dd><a class="version" href="/documentation/stable/{{ version }}">{{ version }}</a></dd>
       {% endfor %}
     </dl>
   </div>

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -12,6 +12,12 @@
       {% endfor %}
     </dl>
     {% endif %}
+    <dl>
+      <dt>Previous Releases</dt>
+      {% for version in version_list %}
+        <dd><a class="version" href"/documentation/stable/{{ version }}">{{ version }}</a></dd>
+      {% endfor %}
+    </dl>
   </div>
   <script>
     jQuery('.version').click((evt) => {

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# Script for pushing the documentation to the qiskit.org repository.
+# Script for pushing the stable documentation.
 set -e
 
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Script for pushing the documentation to the qiskit.org repository.
+set -e
+
+curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
+sudo apt-get install -y ./rclone.deb
+
+RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
+
+echo "show current dir: "
+pwd
+
+CURRENT_TAG=`git describe --abbrev=0`
+IFS='.'
+read -ra VERSION <<< "$CURRENT_TAG"
+STABLE_VERSION="${VERSION[0]}\.${VERSION[1]}"
+
+# Build the documentation.
+tox -edocs -- -D content_prefix=documentation/stable/$STABLE_VERSION -j auto
+
+# Push to qiskit.org website
+openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
+echo "Pushing built docs to stable site"
+rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/stable/$STABLE_VERSION

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -34,4 +34,4 @@ tox -edocs -- -D content_prefix=documentation/stable/$STABLE_VERSION -j auto
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to stable site"
-rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/stable/$STABLE_VERSION
+rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/stable/$STABLE_VERSION

--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -7,3 +7,4 @@ nature/**
 finance/**
 experiments/**
 retworkx/**
+stable/**


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support for hosting stable versions of the
documentation moving forward. This is accomplished by adding a new ci
workflow on tags that will upload docs to stable/$VERSION where $VERSION
is the first 2 components ('major.minor') from the version string. This
will let us maintain a hosted copy of each minor release of
documentation for users still running on older versions. The version
template and custom sphinx extensions are updated to determine the list
of versions from the current state of the git repo.

This PR assumes that we've manually updated 0.24.x, 0.25.x, and 0.26.x
to 'documentation/stable/0.24', 'documentation/stable/0.25', and
'documentation/stable/0.26' respectively. This is a blocker for merging
this because until that done the version menu will have broken links.

### Details and comments