### PR TITLE
Add redirects for application tutorials

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,7 +1,4 @@
 astroid==2.3.3
 pylint==2.4.4
-cryptography==2.5.0
-docplex==2.15.194
-scipy==1.5.4
 decorator==4.4.2
 docutils==0.16

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,12 +76,71 @@ extensions = [
     'sphinx_reredirects'
 ]
 
+optimization_tutorials = [
+    '1_quadratic_program',
+    '2_converters_for_quadratic_programs',
+    '3_minimum_eigen_optimizer',
+    '4_grover_optimizer',
+    '5_admm_optimizer',
+    '6_examples_max_cut_and_tsp',
+    '7_examples_vehicle_routing',
+    '8_cvar_optimization'
+]
+
+finance_tutorials = [
+    '01_portfolio_optimization',
+    '02_portfolio_diversification',
+    '03_european_call_option_pricing',
+    '04_european_put_option_pricing',
+    '05_bull_spread_pricing',
+    '06_basket_option_pricing',
+    '07_asian_barrier_spread_pricing',
+    '08_fixed_income_pricing',
+    '09_credit_risk_analysis',
+    '10_qgan_option_pricing',
+    '11_time_series',
+]
+
+chemistry_tutorials = [
+    '01_electronic_structure',
+    '02_vibronic_structure',
+    '03_ground_state_solvers',
+    '04_excited_states_solvers',
+    '05_Sampling_potential_energy_surfaces',
+    '06_calculating_thermodynamic_observables',
+]
+
+ml_tutorials = [
+    '01_qsvm_classification',
+    '02_qsvm_multiclass',
+    '03_vqc',
+    '04_qgans_for_loading_random_distributions',
+]
+
 # -----------------------------------------------------------------------------
 # Redirects
 # ----------------------------------------------------------------------------- 
 redirects = {
     "install": "getting_started.html",
 }
+
+for tutorial in optimization_tutorials:
+    redirects['tutorials/optimization/%s' % tutorial] =  "https://qiskit.org/documentation/optimization/tutorials/%s.html" % tutorial
+
+for tutorial in finance_tutorials:
+    redirects['tutorials/finance/%s' % tutorial] = "https://qiskit.org/documentation/finance/tutorials/%s.html" % tutorial
+
+for tutorial in chemistry_tutorials:
+    redirects["tutorials/chemistry/%s" % tutorial] = "https://qiskit.org/documentation/nature/tutorials/%s.html" % tutorial
+
+for tutorial in ml_tutorials:
+    # None of the machine learning tutorials exist in their former form (except for qgan)
+    # just redirect to the tutorials index:
+    if tutorial == '04_qgans_for_loading_random_distributions':
+        redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/%s.html" % tutorial
+    else:
+        redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine_learning/tutorials/index.html"
+
 
 nbsphinx_timeout = 300
 nbsphinx_execute = os.getenv('QISKIT_DOCS_BUILD_TUTORIALS', 'never')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,8 @@ optimization_tutorials = [
     '5_admm_optimizer',
     '6_examples_max_cut_and_tsp',
     '7_examples_vehicle_routing',
-    '8_cvar_optimization'
+    '8_cvar_optimization',
+    'index.html'
 ]
 
 finance_tutorials = [
@@ -99,6 +100,7 @@ finance_tutorials = [
     '09_credit_risk_analysis',
     '10_qgan_option_pricing',
     '11_time_series',
+    'index.html'
 ]
 
 chemistry_tutorials = [
@@ -108,6 +110,7 @@ chemistry_tutorials = [
     '04_excited_states_solvers',
     '05_Sampling_potential_energy_surfaces',
     '06_calculating_thermodynamic_observables',
+    'index.html'
 ]
 
 ml_tutorials = [
@@ -115,6 +118,7 @@ ml_tutorials = [
     '02_qsvm_multiclass',
     '03_vqc',
     '04_qgans_for_loading_random_distributions',
+    'index.html'
 ]
 
 # -----------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ for tutorial in ml_tutorials:
     if tutorial == '04_qgans_for_loading_random_distributions':
         redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/%s.html" % tutorial
     else:
-        redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine_learning/tutorials/index.html"
+        redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/index.html"
 
 
 nbsphinx_timeout = 300

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,21 +125,16 @@ redirects = {
 }
 
 for tutorial in optimization_tutorials:
-    redirects['tutorials/optimization/%s' % tutorial] =  "https://qiskit.org/documentation/optimization/tutorials/%s.html" % tutorial
+    redirects['tutorials/optimization/%s' % tutorial] =  "https://qiskit.org/documentation/optimization/tutorials/index.html"
 
 for tutorial in finance_tutorials:
-    redirects['tutorials/finance/%s' % tutorial] = "https://qiskit.org/documentation/finance/tutorials/%s.html" % tutorial
+    redirects['tutorials/finance/%s' % tutorial] = "https://qiskit.org/documentation/finance/tutorials/index.html"
 
 for tutorial in chemistry_tutorials:
-    redirects["tutorials/chemistry/%s" % tutorial] = "https://qiskit.org/documentation/nature/tutorials/%s.html" % tutorial
+    redirects["tutorials/chemistry/%s" % tutorial] = "https://qiskit.org/documentation/nature/tutorials/index.html"
 
 for tutorial in ml_tutorials:
-    # None of the machine learning tutorials exist in their former form (except for qgan)
-    # just redirect to the tutorials index:
-    if tutorial == '04_qgans_for_loading_random_distributions':
-        redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/%s.html" % tutorial
-    else:
-        redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/index.html"
+    redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/index.html"
 
 
 nbsphinx_timeout = 300

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -79,64 +79,6 @@ Operators
 
    tutorials/operators/*
 
-
-Optimization
-============
-
-.. attention:: Deprecation warning
-
-   The following tutorials contain calls to deprecated functionality.
-   See the `qiskit-optimization <https://qiskit.org/documentation/optimization/>`_
-   application for the updated versions.
-
-.. nbgallery::
-   :glob:
-
-   tutorials/optimization/*
-
-Finance
-=======
-
-.. attention:: Deprecation warning
-
-   The following tutorials contain calls to deprecated functionality.
-   See the `qiskit-finance <https://qiskit.org/documentation/finance/>`_
-   application for the updated versions.
-
-.. nbgallery::
-   :glob:
-
-   tutorials/finance/*
-
-Chemistry
-=========
-
-.. attention:: Deprecation warning
-
-   The following tutorials contain calls to deprecated functionality.
-   See the `qiskit-nature <https://qiskit.org/documentation/nature/>`_
-   application for the updated versions.
-
-.. nbgallery::
-   :glob:
-
-   tutorials/chemistry/*
-
-Machine learning
-================
-
-.. attention:: Deprecation warning
-
-   The following tutorials contain calls to deprecated functionality.
-   See the `qiskit-machine-learning <https://qiskit.org/documentation/machine-learning/>`_
-   application for the updated versions.
-
-.. nbgallery::
-   :glob:
-
-   tutorials/machine_learning/*
-
-
 .. Hiding - Indices and tables
    :ref:`genindex`
    :ref:`modindex`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ pillow>=4.2.1
 seaborn>=0.9.0
 nbsphinx
 cvxpy<1.1.0
-pyscf<1.7.4
 tweedledum>=1.0.0,<2.0.0
 networkx>=2.3
 sphinx-reredirects

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ extras =
 deps =
   -r requirements-dev.txt
   sphinx-intl
-  cplex
 commands =
   sphinx-build -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The tutorials for the application modules have been moved out of the
qiskit-tutorials repository to the application module documentation.
This commit adds the approriate redirects so existing links work as
expected. It also updates the tutorials index and requirements list
to remove things that were only there for the application tutorials.

### Details and comments