### PR TITLE
Add back cplex to docs job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ extras =
 deps =
   -r requirements-dev.txt
   sphinx-intl
+  cplex
 commands =
   sphinx-build -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #1266 we removed the cplex requirement from the
tox docs job because we removed the application module tutorials which
were dependent on this. However, that neglected to take into account the
aqua migration guide tutorial which we're still going to host and it
requires cplex to execute. Removing it has caused the docs builds to
fail on the publish job which is the only place we execute the migration
tutorial. This commit adds cplex back to fix the job and unblock docs
updates.

### Details and comments


