### PR TITLE
Fix generate authors script

### DIFF
--- a/tools/generate_authors.py
+++ b/tools/generate_authors.py
@@ -74,7 +74,10 @@ def main(repos=None, output_path=None):
         co_authors = [signed.split(":", 1)[1].strip() for signed in co_authors if signed]
 
         for author_str in co_authors:
-            author, email = author_str.split('<')
+            try:
+                author, email = author_str.split('<')
+            except ValueError:
+                continue
             author = author.strip()
             email = email[:-1].strip()
             mailmap_contact = '<' + email + '>'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The generate authors script has been failing when qiskit-bot goes to
update it because there was an invalidly formatted co-authorship line
in one of the commit messages. This was causing the parser to fail
because it couldn't find an email address for the co-author. This commit
updates the script so if that occurs it just skips that line.

### Details and comments


