### PR TITLE
Remove pins on application module optional extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,22 +35,22 @@ requirements = [
 
 
 optimization_extra = [
-    "qiskit-optimization==0.2.1",
+    "qiskit-optimization>=0.2.1",
 ]
 
 
 finance_extra = [
-    "qiskit-finance==0.2.0",
+    "qiskit-finance>=0.2.0",
 ]
 
 
 machine_learning_extra = [
-    "qiskit-machine-learning==0.2.0",
+    "qiskit-machine-learning>=0.2.0",
 ]
 
 
 nature_extra = [
-    "qiskit-nature==0.1.5",
+    "qiskit-nature>=0.1.5",
 ]
 
 experiments_extra = [


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the pinning on the optional extras for the
application packages. We shouldn't be doing this as these are downstream
dependencies of qiskit and we only provide these targets as an
installation convenience. As the packages are separate pinning things
just make this more complicated for qiskit to release (and leads to
extra package versions). This was mostly an artifact of the release
automation, but the behavior there is being updated in
Qiskit/qiskit-bot#14 to not bump anything around optional extras.

### Details and comments

Depends-on: Qiskit/qiskit-bot#14