### PR TITLE
Fix bash syntax is docs deploy tag script

### DIFF
--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -26,12 +26,12 @@ pwd
 CURRENT_TAG=`git describe --abbrev=0`
 IFS='.'
 read -ra VERSION <<< "$CURRENT_TAG"
-STABLE_VERSION="${VERSION[0]}\.${VERSION[1]}"
+STABLE_VERSION=${VERSION[0]}.${VERSION[1]}
 
 # Build the documentation.
-tox -edocs -- -D content_prefix=documentation/stable/$STABLE_VERSION -j auto
+tox -edocs -- -D content_prefix=documentation/stable/"$STABLE_VERSION" -j auto
 
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to stable site"
-rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/stable/$STABLE_VERSION
+rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/stable/"$STABLE_VERSION"

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -26,7 +26,7 @@ pwd
 CURRENT_TAG=`git describe --abbrev=0`
 IFS='.'
 read -ra VERSION <<< "$CURRENT_TAG"
-STABLE_VERSION=${VERSION[0]}.${VERSION[1]}
+STABLE_VERSION =`echo $VERSION | cut -d "." -f -2`
 
 # Build the documentation.
 tox -edocs -- -D content_prefix=documentation/stable/"$STABLE_VERSION" -j auto


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes some bash syntax issues in the docs deploy tag script.
These were preventing the script from running successfully as the version
number was not being constructed correctly and the script would error
when calling sphinx-build. This should fix the jobs so we no longer need
to manually upload stable documentation at release time.

### Details and comments


