### PR TITLE
Add stable 0.19 docs to version list

### DIFF
--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -95,6 +95,8 @@ def _get_version_list():
         #TODO: When 1.0.0 add code to handle 0.x version list
         version_list = []
         pass
+    # Prepend version 0.19 which was built and uploaded manually:
+    version_list.insert(0, '0.19')
     return version_list
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It was requested that we have the 0.19 docs hosted on the documentation
page even though we only started doing stable doc builds at the 0.24
release. After a little trouble with dependency versions (things have
changed a bit in the past 14 months) I manually checked out, built, and
uploaded the 0.19 docs which are now hosted at:
https://qiskit.org/documentation/stable/0.19/ But, to make this version
discoverable we need to include 0.19 in the version list. This commit
manually prepends 0.19 to the version_list as it was a one off so it's
discoverable for users interested in reading the docs for the historical
version.

### Details and comments


