### PR TITLE
docs: fix "circuit.draw" in intro tutorial

### DIFF
--- a/docs/intro_tutorial1.rst
+++ b/docs/intro_tutorial1.rst
@@ -19,6 +19,7 @@ subsequent sections:
 
 .. jupyter-execute::
 
+    import matplotlib.pyplot as plt
     import numpy as np
     from qiskit import QuantumCircuit, transpile
     from qiskit.providers.aer import QasmSimulator
@@ -54,7 +55,8 @@ subsequent sections:
     print("\nTotal count for 00 and 11 are:",counts)
 
     # Draw the circuit
-    circuit.draw()
+    circuit.draw(output="mpl")
+    plt.show()
 
 .. jupyter-execute::
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/Qiskit/qiskit/issues/579

### Details and comments

The `circuit.draw` command is not working.
