### PR TITLE
Remove cvxpy cap

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ ipywidgets>=7.3.
 pillow>=4.2.1
 seaborn>=0.9.0
 nbsphinx
-cvxpy<1.1.0
+cvxpy
 tweedledum>=1.0.0,<2.0.0
 networkx>=2.3
 sphinx-reredirects


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The cvxpy cap is forcing a really ancient version of cvxpy to be
installed in the  docs publishing jobs causing the tutorials to fail.
I'm not quite sure why it's just happening today while last week
things worked fine. I expect it is another package's requirements
confusing pip's dependency solver. But either way this cap is no
longer needed as the tutorials ci test job runs fine with cvxpy
unconstrained.

### Details and comments


