### PR TITLE
Actually bump ignis version in benchmarks

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -27,7 +27,7 @@
         "python -mpip install seaborn",
         "python -mpip install pygments",
         "python -mpip install {wheel_file}",
-        "python -mpip install -U qiskit-ignis==0.2.0",
+        "python -mpip install -U qiskit-ignis==0.6.0",
         "python -mpip install -U python-constraint"
       ],
     "uninstall_command": [

--- a/test/benchmarks/state_tomography.py
+++ b/test/benchmarks/state_tomography.py
@@ -24,7 +24,7 @@ from qiskit.quantum_info import state_fidelity
 class StateTomographyBench:
     params = [2, 3, 4, 5]
     param_names = ['n_qubits']
-    version = '0.2.0'
+    version = '0.6.0'
     timeout = 120.0
 
     def setup(self, _):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1324 as part of the updates to the randomized benchmarking
benchmarks the version string in the benchmark class was bumped to
the latest ignis version to do 2 things, first indicate the benchmark
code had significantly changed to differentiate new results from old
ones and second to update the ignis version to the latest release in the
benchmarks. However on the second point the ignis version installed was
never actually updated. This commit fixes this oversight and updates the
ignis version in the asv config and also updates the state tomography
benchmark version to indicate that we're running with ignis 0.6.0 now
instead of 0.2.0 that we had been using previously.

### Details and comments