### PR TITLE
Drop track_* passes benchmarks and fix cxdirection benchmark

### DIFF
--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -62,52 +62,18 @@ class PassBenchmarks:
         apply_pass.property_set['layout'] = self.layout
         self.dag = apply_pass.run(self.enlarge_dag)
         self.backend_props = fake_singapore.FakeSingapore().properties()
+        self.routed_dag = StochasticSwap(self.coupling_map,
+                                         seed=42).run(self.dag)
 
     def time_stochastic_swap(self, _, __):
         swap = StochasticSwap(self.coupling_map, seed=42)
         swap.property_set['layout'] = self.layout
         swap.run(self.dag)
 
-    def track_stochastic_swap_depth(self, _, __):
-        swap = StochasticSwap(self.coupling_map, seed=42)
-        swap.property_set['layout'] = self.layout
-        return swap.run(self.dag).depth()
-
-    def track_stochastic_swap_swap_count(self, _, __):
-        swap = StochasticSwap(self.coupling_map, seed=42)
-        swap.property_set['layout'] = self.layout
-        return swap.run(self.dag).count_ops().get('swap')
-
-    # Disable lookahead swap benchmarks due to timeout.
-    # def time_lookahead_swap(self, _, __):
-    #     swap = LookaheadSwap(self.coupling_map)
-    #     swap.property_set['layout'] = self.layout
-    #     swap.run(self.dag)
-
-    # def track_lookahead_swap_depth(self, _, __):
-    #     swap = LookaheadSwap(self.coupling_map)
-    #     swap.property_set['layout'] = self.layout
-    #     return swap.run(self.dag).depth()
-
-    # def track_lookahead_swap_swap_count(self, _, __):
-    #     swap = LookaheadSwap(self.coupling_map)
-    #     swap.property_set['layout'] = self.layout
-    #     return swap.run(self.dag).depth().count_ops().get('swap')
-
     def time_basic_swap(self, _, __):
         swap = BasicSwap(self.coupling_map)
         swap.property_set['layout'] = self.layout
         swap.run(self.dag)
-
-    def track_basic_swap_depth(self, _, __):
-        swap = BasicSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        return swap.run(self.dag).depth()
-
-    def track_basic_swap_swap_count(self, _, __):
-        swap = BasicSwap(self.coupling_map)
-        swap.property_set['layout'] = self.layout
-        return swap.run(self.dag).depth().count_ops().get('swap')
 
     def time_csp_layout(self, _, __):
         CSPLayout(self.coupling_map, seed=42).run(self.fresh_dag)
@@ -121,14 +87,7 @@ class PassBenchmarks:
         layout.run(self.dag)
 
     def time_cxdirection(self, _, __):
-        CXDirection(self.coupling_map).run(self.dag)
-
-    def track_cxdirection_depth(self, _, __):
-        return CXDirection(self.coupling_map).run(self.dag).depth()
-
-    def track_cxdirection_cnot_count(self, _, __):
-        return CXDirection(
-            self.coupling_map).run(self.dag).count_ops().get('cx')
+        CXDirection(self.coupling_map).run(self.routed_dag)
 
     def time_apply_layout(self, _, __):
         layout = ApplyLayout()

--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -62,8 +62,6 @@ class PassBenchmarks:
         apply_pass.property_set['layout'] = self.layout
         self.dag = apply_pass.run(self.enlarge_dag)
         self.backend_props = fake_singapore.FakeSingapore().properties()
-        self.routed_dag = StochasticSwap(self.coupling_map,
-                                         seed=42).run(self.dag)
 
     def time_stochastic_swap(self, _, __):
         swap = StochasticSwap(self.coupling_map, seed=42)
@@ -86,9 +84,6 @@ class PassBenchmarks:
         layout.property_set['layout'] = self.layout
         layout.run(self.dag)
 
-    def time_cxdirection(self, _, __):
-        CXDirection(self.coupling_map).run(self.routed_dag)
-
     def time_apply_layout(self, _, __):
         layout = ApplyLayout()
         layout.property_set['layout'] = self.layout
@@ -107,9 +102,6 @@ class PassBenchmarks:
     def time_check_map(self, _, __):
         CheckMap(self.coupling_map).run(self.dag)
 
-    def time_check_cx_direction(self, _, __):
-        CheckCXDirection(self.coupling_map).run(self.dag)
-
     def time_trivial_layout(self, _, __):
         TrivialLayout(self.coupling_map).run(self.fresh_dag)
 
@@ -118,3 +110,50 @@ class PassBenchmarks:
 
     def time_noise_adaptive_layout(self, _, __):
         NoiseAdaptiveLayout(self.backend_props).run(self.fresh_dag)
+
+
+class RoutedPassBenchmarks:
+    params = ([5, 14, 20],
+              [1024])
+
+    param_names = ['n_qubits', 'depth']
+    timeout = 300
+
+    def setup(self, n_qubits, depth):
+        seed = 42
+        self.circuit = random_circuit(n_qubits, depth, measure=True,
+                                      conditional=True, reset=True, seed=seed,
+                                      max_operands=2)
+        self.fresh_dag = circuit_to_dag(self.circuit)
+        self.basis_gates = ['u1', 'u2', 'u3', 'cx', 'iid']
+        self.cmap = [[0, 1], [1, 0], [1, 2], [1, 6], [2, 1], [2, 3], [3, 2],
+                     [3, 4], [3, 8], [4, 3], [5, 6], [5, 10], [6, 1], [6, 5],
+                     [6, 7], [7, 6], [7, 8], [7, 12], [8, 3], [8, 7], [8, 9],
+                     [9, 8], [9, 14], [10, 5], [10, 11], [11, 10], [11, 12],
+                     [11, 16], [12, 7], [12, 11], [12, 13], [13, 12], [13, 14],
+                     [13, 18], [14, 9], [14, 13], [15, 16], [16, 11], [16, 15],
+                     [16, 17], [17, 16], [17, 18], [18, 13], [18, 17],
+                     [18, 19], [19, 18]]
+        self.coupling_map = CouplingMap(self.cmap)
+
+        layout_pass = DenseLayout(self.coupling_map)
+        layout_pass.run(self.fresh_dag)
+        self.layout = layout_pass.property_set['layout']
+        full_ancilla_pass = FullAncillaAllocation(self.coupling_map)
+        full_ancilla_pass.property_set['layout'] = self.layout
+        self.full_ancilla_dag = full_ancilla_pass.run(self.fresh_dag)
+        enlarge_pass = EnlargeWithAncilla()
+        enlarge_pass.property_set['layout'] = self.layout
+        self.enlarge_dag = enlarge_pass.run(self.full_ancilla_dag)
+        apply_pass = ApplyLayout()
+        apply_pass.property_set['layout'] = self.layout
+        self.dag = apply_pass.run(self.enlarge_dag)
+        self.backend_props = fake_singapore.FakeSingapore().properties()
+        self.routed_dag = StochasticSwap(self.coupling_map,
+                                         seed=42).run(self.dag)
+
+    def time_cxdirection(self, _, __):
+        CXDirection(self.coupling_map).run(self.routed_dag)
+
+    def time_check_cx_direction(self, _, __):
+        CheckCXDirection(self.coupling_map).run(self.routed_dag)

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -44,11 +44,6 @@ class Collect2QPassBenchmarks:
         _pass.property_set['block_list'] = self.block_list
         _pass.run(self.dag)
 
-    def track_consolidate_blocks_depth(self, _, __):
-        _pass = ConsolidateBlocks()
-        _pass.property_set['block_list'] = self.block_list
-        return _pass.run(self.dag).depth()
-
 
 class CommutativeAnalysisPassBenchmarks:
     params = ([5, 14, 20],
@@ -73,11 +68,6 @@ class CommutativeAnalysisPassBenchmarks:
         _pass.property_set['commutation_set'] = self.commutation_set
         _pass.run(self.dag)
 
-    def track_commutative_cancellation_depth(self, _, __):
-        _pass = CommutativeCancellation()
-        _pass.property_set['commutation_set'] = self.commutation_set
-        return _pass.run(self.dag).depth()
-
 
 class UnrolledPassBenchmarks:
     params = ([5, 14, 20],
@@ -97,9 +87,6 @@ class UnrolledPassBenchmarks:
     def time_optimize_1q(self, _, __):
         Optimize1qGates().run(self.unrolled_dag)
 
-    def track_optimize_1q_depth(self, _, __):
-        return Optimize1qGates().run(self.unrolled_dag).depth()
-
 
 class PassBenchmarks:
     params = ([5, 14, 20],
@@ -117,9 +104,6 @@ class PassBenchmarks:
 
     def time_unroller(self, _, __):
         Unroller(self.basis_gates).run(self.dag)
-
-    def track_unroller_depth(self, _, __):
-        return Unroller(self.basis_gates).run(self.dag).depth()
 
     def time_depth_pass(self, _, __):
         Depth().run(self.dag)
@@ -154,14 +138,8 @@ class PassBenchmarks:
     def time_decompose_pass(self, _, __):
         Decompose().run(self.dag)
 
-    def track_decompose_depth(self, _, __):
-        return Decompose().run(self.dag).depth()
-
     def time_unroll_3q_or_more(self, _, __):
         Unroll3qOrMore().run(self.dag)
-
-    def track_unroll_3q_or_more_depth(self, _, __):
-        return Unroll3qOrMore().run(self.dag).depth()
 
     def time_commutation_analysis(self, _, __):
         CommutationAnalysis().run(self.dag)
@@ -169,32 +147,17 @@ class PassBenchmarks:
     def time_remove_reset_in_zero_state(self, _, __):
         RemoveResetInZeroState().run(self.dag)
 
-    def track_remove_reset_in_zero_state(self, _, __):
-        return RemoveResetInZeroState().run(self.dag).depth()
-
     def time_collect_2q_blocks(self, _, __):
         Collect2qBlocks().run(self.dag)
 
     def time_optimize_swap_before_measure(self, _, __):
         OptimizeSwapBeforeMeasure().run(self.dag)
 
-    def track_optimize_swap_before_measure_depth(self, _, __):
-        return OptimizeSwapBeforeMeasure().run(self.dag).depth()
-
     def time_barrier_before_final_measurements(self, _, __):
         BarrierBeforeFinalMeasurements().run(self.dag)
-
-    def track_barrier_before_final_measurement(self, _, __):
-        BarrierBeforeFinalMeasurements().run(self.dag).depth()
 
     def time_remove_diagonal_gates_before_measurement(self, _, __):
         RemoveDiagonalGatesBeforeMeasure().run(self.dag)
 
-    def track_remove_diagonal_gates_before_measurement(self, _, __):
-        return RemoveDiagonalGatesBeforeMeasure().run(self.dag).depth()
-
     def time_remove_final_measurements(self, _, __):
         RemoveFinalMeasurements().run(self.dag)
-
-    def track_remove_final_measurements_depth(self, _, __):
-        return RemoveFinalMeasurements().run(self.dag).depth()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In preparation for adding benchmarks for additional benchmarks for new
passes this commit does some house keeping on the existing passes
benchmarks. Primarily it removes the track_* passes which were used to
measure the depth and cnot count of output from various passes. But in
practice these provided little value at the cost of multiplying our
runtime. By removing them we open up additional time for more useful
benchmarks. At the same time this fixes the cxdirection benchmarks
which didn't work because the pass expects to run on a routed circuit
and we were only passing a circuit that had run layout.

### Details and comments