### PR TITLE
Add benchmarks for missing passes

### DIFF
--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -68,6 +68,11 @@ class PassBenchmarks:
         swap.property_set['layout'] = self.layout
         swap.run(self.dag)
 
+    def time_sabre_swap(self, _, __):
+        swap = SabreSwap(self.coupling_map, seed=42)
+        swap.property_set['layout'] = self.layout
+        swap.run(self.dag)
+
     def time_basic_swap(self, _, __):
         swap = BasicSwap(self.coupling_map)
         swap.property_set['layout'] = self.layout
@@ -111,6 +116,9 @@ class PassBenchmarks:
     def time_noise_adaptive_layout(self, _, __):
         NoiseAdaptiveLayout(self.backend_props).run(self.fresh_dag)
 
+    def time_sabre_layout(self, _, __):
+        SabreLayout(self.coupling_map, seed=42).run(self.fresh_dag)
+
 
 class RoutedPassBenchmarks:
     params = ([5, 14, 20],
@@ -152,8 +160,17 @@ class RoutedPassBenchmarks:
         self.routed_dag = StochasticSwap(self.coupling_map,
                                          seed=42).run(self.dag)
 
-    def time_cxdirection(self, _, __):
+    def time_cx_direction(self, _, __):
         CXDirection(self.coupling_map).run(self.routed_dag)
 
     def time_check_cx_direction(self, _, __):
         CheckCXDirection(self.coupling_map).run(self.routed_dag)
+
+    def time_gate_direction(self, _, __):
+        GateDirection(self.coupling_map).run(self.routed_dag)
+
+    def time_check_gate_direction(self, _, __):
+        CheckGateDirection(self.coupling_map).run(self.routed_dag)
+
+    def time_check_map(self, _, __):
+        CheckMap(self.coupling_map).run(self.routed_dag)

--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -160,7 +160,7 @@ class RoutedPassBenchmarks:
         self.routed_dag = StochasticSwap(self.coupling_map,
                                          seed=42).run(self.dag)
 
-    def time_cx_direction(self, _, __):
+    def time_cxdirection(self, _, __):
         CXDirection(self.coupling_map).run(self.routed_dag)
 
     def time_check_cx_direction(self, _, __):

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -196,3 +196,20 @@ class PassBenchmarks:
 
     def time_remove_barriers(self, _, __):
         RemoveBarriers().run(self.dag)
+
+
+class MultiQBlockPassBenchmarks:
+    params = ([5, 14, 20],
+              [1024], [1, 2, 3, 4, 5])
+
+    param_names = ['n_qubits', 'depth', 'lock_max_size']
+    timeout = 300
+
+    def setup(self, n_qubits, depth, _):
+        seed = 42
+        self.circuit = random_circuit(n_qubits, depth, measure=True,
+                                      conditional=True, reset=True, seed=seed)
+        self.dag = circuit_to_dag(self.circuit)
+
+    def time_collect_multiq_block(self, _, __, max_block_size):
+        CollectMultiQBlocks(max_block_size).run(self.dag)

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -92,7 +92,7 @@ class UnrolledPassBenchmarks:
 class MultipleBasisPassBenchmarks:
     params = ([5, 14, 20],
               [1024],
-              [['u', 'cx'], ['rx', 'ry', 'rz', 'r', 'rxx'],
+              [['u', 'cx', 'id'], ['rx', 'ry', 'rz', 'r', 'rxx', 'id'],
                ['rz', 'x', 'sx', 'cx', 'id']])
 
     param_names = ['n_qubits', 'depth', 'basis_gates']

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -14,9 +14,10 @@
 
 # pylint: disable=no-member,invalid-name,missing-docstring,no-name-in-module
 # pylint: disable=attribute-defined-outside-init,unsubscriptable-object
-# pylint: disable=unused-wildcard-import,wildcard-import
+# pylint: disable=unused-wildcard-import,wildcard-import,undefined-variable
 
 
+from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as SEL
 from qiskit.transpiler.passes import *
 from qiskit.converters import circuit_to_dag
 
@@ -86,6 +87,31 @@ class UnrolledPassBenchmarks:
 
     def time_optimize_1q(self, _, __):
         Optimize1qGates().run(self.unrolled_dag)
+
+
+class MultipleBasisPassBenchmarks:
+    params = ([5, 14, 20],
+              [1024],
+              [['u', 'cx'], ['rx', 'ry', 'rz', 'r', 'rxx'],
+               ['rz', 'x', 'sx', 'cx', 'id']])
+
+    param_names = ['n_qubits', 'depth', 'basis_gates']
+    timeout = 300
+
+    def setup(self, n_qubits, depth, basis_gates):
+        seed = 42
+        self.circuit = random_circuit(n_qubits, depth, measure=True, seed=seed)
+        self.dag = circuit_to_dag(self.circuit)
+        self.basis_gates = basis_gates
+
+    def time_optimize_1q_decompose(self, _, __, ___):
+        Optimize1qGatesDecomposition(self.basis_gates).run(self.dag)
+
+    def time_optimize_1q_commutation(self, _, __, ___):
+        Optimize1qGatesSimpleCommutation(self.basis_gates).run(self.dag)
+
+    def time_basis_translator(self, _, __, ___):
+        BasisTranslator(SEL, self.basis_gates).run(self.dag)
 
 
 class PassBenchmarks:
@@ -161,3 +187,12 @@ class PassBenchmarks:
 
     def time_remove_final_measurements(self, _, __):
         RemoveFinalMeasurements().run(self.dag)
+
+    def time_contains_instruction(self, _, __):
+        ContainsInstruction('cx').run(self.dag)
+
+    def time_gates_in_basis(self, _, __):
+        GatesInBasis(self.basis_gates).run(self.dag)
+
+    def time_remove_barriers(self, _, __):
+        RemoveBarriers().run(self.dag)

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -202,7 +202,7 @@ class MultiQBlockPassBenchmarks:
     params = ([5, 14, 20],
               [1024], [1, 2, 3, 4, 5])
 
-    param_names = ['n_qubits', 'depth', 'lock_max_size']
+    param_names = ['n_qubits', 'depth', 'max_block_size']
     timeout = 300
 
     def setup(self, n_qubits, depth, _):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds runtime benchmarks to the passes and mapping_passes
benchmark modules to measure additional transpiler passes in isolation
that we didn't have coverage for previously. Primarily of importance
here are the basis translator and the optimize 1q decomposition passes
which are in the preset pass managers but didn't have standalone
benchmark coverage. One pass excluded here is the TemplateOptimization
pass which would have been good to add to the benchmark but it is
exceedingly slow and took well more than 5 min per iteration.

### Details and comments


