### PR TITLE
Add a benchmark of `SparsePauliOp.__add__`

### DIFF
--- a/test/benchmarks/quantum_info.py
+++ b/test/benchmarks/quantum_info.py
@@ -182,6 +182,9 @@ class SparsePauliOpBench:
         self.p2 = SparsePauliOp(
             random_pauli_list(num_qubits=num_qubits, size=length, phase=True))
 
+    def time_add(self, _, __):
+        self.p1.add(self.p2)
+
     def time_compose(self, _, __):
         self.p1.compose(self.p2)
 

--- a/test/benchmarks/quantum_info.py
+++ b/test/benchmarks/quantum_info.py
@@ -183,7 +183,7 @@ class SparsePauliOpBench:
             random_pauli_list(num_qubits=num_qubits, size=length, phase=True))
 
     def time_add(self, _, __):
-        self.p1.add(self.p2)
+        _ = self.p1 + self.p2
 
     def time_compose(self, _, __):
         self.p1.compose(self.p2)

--- a/test/benchmarks/quantum_info.py
+++ b/test/benchmarks/quantum_info.py
@@ -182,9 +182,6 @@ class SparsePauliOpBench:
         self.p2 = SparsePauliOp(
             random_pauli_list(num_qubits=num_qubits, size=length, phase=True))
 
-    def time_add(self, _, __):
-        _ = self.p1 + self.p2
-
     def time_compose(self, _, __):
         self.p1.compose(self.p2)
 
@@ -193,6 +190,10 @@ class SparsePauliOpBench:
 
     def time_tensor(self, _, __):
         self.p1.tensor(self.p2)
+
+    def time_add(self, _, __):
+        _ = self.p1 + self.p2
+    time_add.params = [[50, 100, 150, 200], [10000]]
 
     def time_to_list(self, _, __):
         self.p1.to_list()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add a benchmark of `SparsePauliOp._add` via `SparsePauliOp.__add__`.
This method is an important building block of various algorithms (I'm working on the qubit mapper of Qiskit nature).
I'm working on the performance improvement of this method. I hope the improvement will be visible.
https://github.com/Qiskit/qiskit-terra/pull/7138
https://github.com/Qiskit/qiskit-nature/pull/397

### Details and comments


