### PR TITLE
Add dynamics to other-builds.txt list

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -8,3 +8,4 @@ finance/**
 experiments/**
 retworkx/**
 stable/**
+dynamics/**


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The other-builds.txt list is used to maintain a list of directories to
not overwrite when we sync new docs builds to COS. These are other doc
builds hosted in the same namespace in the hosted bucket. With the
pending release of the qiskit-dynamics project it will be uploading it's
documentation to 'documentation/dynamics' and we need to add this to the
exclude list so that future docs updates for the root documentation do
not accidentally delete the dynamics documentation. This commit adds
'dynamics/**'  to the other-builds.txt list for this reason.

### Details and comments