### PR TITLE
Fix linter errors after doc generation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 commands =
   pycodestyle test
   pylint -rn --rcfile={toxinidir}/.pylintrc test
-  doc8 docs --ignore-path docs/_templates
+  doc8 docs --ignore-path docs/_templates --ignore-path docs/stubs
 
 [testenv:asv]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This pull request fixes linter errors that result after building the docs locally.

### Details and comments

I have found that `tox -elint` results in errors if it is run after the documentation has been built using `tox -edocs`.  Currently, there are 7098 different `D005 No newline at end of file` errors because the generated `rst` files in `docs/stubs` are lacking trailing newlines.

I can reproduce this problem in a python 3.8 virtual environment with tox 3.24.4.

This commit fixes the errors by ignoring the `docs/stubs` directory.
