### PR TITLE
Pin matplotlib in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials
-          pip install -c constraints.txt -U jupyter sphinx nbsphinx networkx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4' scikit-learn
+          pip install -c constraints.txt -U jupyter sphinx nbsphinx networkx sphinx_rtd_theme 'matplotlib<3.4.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4' scikit-learn
           pip install -c constraints.txt -U .
           sudo apt-get install -y pandoc graphviz
       - name: Run tutorials

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials
-          pip install -c constraints.txt -U jupyter sphinx nbsphinx networkx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4'
+          pip install -c constraints.txt -U jupyter sphinx nbsphinx networkx sphinx_rtd_theme 'matplotlib<3.3.0' qiskit-terra[visualization] cvxpy 'pyscf<1.7.4' scikit-learn
           pip install -c constraints.txt -U .
           sudo apt-get install -y pandoc graphviz
       - name: Run tutorials

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,4 +4,4 @@ cryptography==2.5.0
 scipy==1.5.4
 decorator==4.4.2
 docutils==0.16
-matplotlib==3.2.2
+matplotlib==3.3.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,4 @@ cryptography==2.5.0
 scipy==1.5.4
 decorator==4.4.2
 docutils==0.16
+matplotlib==3.2.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ jupyter
 jupyter-sphinx
 sphinx-panels
 sphinx-gallery
-matplotlib>=2.1,<3.3.0
+matplotlib>=2.1,<3.4.0
 pydot
 ipywidgets>=7.3.
 pillow>=4.2.1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of matplotlib 3.5.0 bloch sphere visualizations
are failing in docs builds. This has been mitigated in terra's main
branch but hasn't been included in a release (but will be fixed in the
upcoming terra 0.19.0 release). Until that is released this commit pins
things in CI to avoid using the new version to unblock ci.

### Details and comments