### PR TITLE
Revise wording in aqua removal release note prelude

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,16 +26,17 @@ Qiskit 0.33.0
 *************
 
 This release officially marks the end of support for the Qiskit Aqua project
-from Qiskit. It was originally deprecated in the 0.25.0 release and as was documented
+in Qiskit. It was originally deprecated in the 0.25.0 release and as was documented
 in that release the ``qiskit-aqua`` package has been removed from the Qiskit
-metapackage, which means in that future release ``pip install qiskit`` will no
-longer include ``qiskit-aqua``. However, note because of limitations in python
-packaging we cannot automatically remove a pre-existing install of ``qiskit-aqua``.
-If you are upgrading from a previous version it's recommended that you manually
-uninstall Qiskit Aqua with ``pip uninstall qiskit-aqua`` or install the metapackage
-in a fresh python environment.
+metapackage, which means ``pip install qiskit`` will no
+longer include ``qiskit-aqua``. However, because of limitations in python
+packaging we cannot automatically remove a pre-existing install of ``qiskit-aqua``
+when upgrading a previous version of Qiskit to this release (or a future release)
+with ``pip install -U qiskit``. If you are upgrading from a previous version it's
+recommended that you manually uninstall Qiskit Aqua with
+``pip uninstall qiskit-aqua`` or install in a fresh python environment.
 
-The application modules that are provided by ``qiskit-aqua`` have been split into
+The application modules that were provided by ``qiskit-aqua`` have been split into
 several new packages:
 ``qiskit-optimization``, ``qiskit-nature``, ``qiskit-machine-learning``, and
 ``qiskit-finance``. These packages can be installed by themselves (via the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The section in the prelude for the 0.33.0 release contained a number of
copy and paste errors (as it was mostly copied from the deprecation note
in 0.25.0). This commit corrects those to make it clear that aqua has
been removed and you only need to uninstall aqua manually when upgrading
from a prior version.

### Details and comments


