### PR TITLE
Set IFS only locally for read in deploy_documentation_tags.sh

### DIFF
--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -25,8 +25,7 @@ pwd
 
 CURRENT_TAG=`git describe --abbrev=0`
 IFS=. read -ra VERSION <<< "$CURRENT_TAG"
-# The "minor" version, so in "0.29.2" it's "29".
-STABLE_VERSION=${VERSION[1]}
+STABLE_VERSION="${VERSION[0]}.${VERSION[1]}"
 
 # Build the documentation.
 tox -edocs -- -D content_prefix=documentation/stable/"$STABLE_VERSION" -j auto

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -24,9 +24,9 @@ echo "show current dir: "
 pwd
 
 CURRENT_TAG=`git describe --abbrev=0`
-IFS='.'
-read -ra VERSION <<< "$CURRENT_TAG"
-STABLE_VERSION=`echo $VERSION | cut -d "." -f -2`
+IFS=. read -ra VERSION <<< "$CURRENT_TAG"
+# The "minor" version, so in "0.29.2" it's "29".
+STABLE_VERSION=${VERSION[1]}
 
 # Build the documentation.
 tox -edocs -- -D content_prefix=documentation/stable/"$STABLE_VERSION" -j auto


### PR DESCRIPTION
### Summary

Previously IFS was set for the whole bash setting, which later affected
the word splitting when the secrets were read from the variables and
split into the openssl command.

This also tidies up the array reading - previously, the `VERSION`
variable was an array (so `echo $VERSION` would be equivalent to
`echo ${VERSION[0]}`), and it was passed to `cut`, which isn't
necessary, since it was already split.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

@mtreinish: I think this is the problem on the docs tag deploy action.
