### PR TITLE
Add garrison's personal email address to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -27,6 +27,7 @@ Diego M. Rodriguez <diego.plan9@gmail.com>
 gadial <gadial@gmail.com>
 Hassi Norlen <hnorlen@us.ibm.com>
 James R. Garrison <garrison@ibm.com>
+James R. Garrison <garrison@ibm.com> <jim@garrison.cc>
 Jay M. Gambetta <jay.gambetta@us.ibm.com>
 Juan Cruz-Benito <juan.cruz@ibm.com>
 Juan Gomez <atilag@gmail.com>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds my personal email address to `.mailmap` so that I will only appear with one name in `Qiskit.bib`, which addresses my comment at https://github.com/Qiskit/qiskit/pull/1373#issuecomment-991414722.

### Details and comments

My very first commit/PR to `Qiskit/qiskit`, for some reason, was changed to use my personal email address [when it was squashed/merged](https://github.com/Qiskit/qiskit/commit/b98d6e9249986f35082885e8c31f9f81b3360f68), even though [the commit I submitted](https://github.com/Qiskit/qiskit/pull/1357/commits/45418d58958aeee474e757d8daf3796c4a1aeeeb) in that PR used my work email address.  In my musings at https://github.com/Qiskit/qiskit-optimization/pull/300, I thought such a change might be due to a bug in mergify[bot], but here it seems to have occurred without mergify, so it must be something about GitHub.
