### PR TITLE
Add benchmarks for circuit scheduling

### DIFF
--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -13,14 +13,18 @@
 # that they have been altered from the originals.
 
 # pylint: disable=invalid-name,missing-docstring
-# pylint: disable=attribute-defined-outside-init,
-# pylint: disable=unused-wildcard-import,wildcard-import
+# pylint: disable=attribute-defined-outside-init
 
 from qiskit import transpile
 from qiskit.circuit.library.standard_gates import XGate
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler import InstructionDurations
-from qiskit.transpiler.passes import *
+from qiskit.transpiler.passes import (
+    TimeUnitConversion,
+    ASAPSchedule,
+    ALAPSchedule,
+    DynamicalDecoupling,
+)
 from qiskit.converters import circuit_to_dag
 
 from .utils import random_circuit

--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=attribute-defined-outside-init,
+# pylint: disable=unused-wildcard-import,wildcard-import
+
+from qiskit import transpile
+from qiskit.circuit.library.standard_gates import XGate
+from qiskit.transpiler import CouplingMap
+from qiskit.transpiler import InstructionDurations
+from qiskit.transpiler.passes import *
+from qiskit.converters import circuit_to_dag
+
+from .utils import random_circuit
+
+
+class SchedulingPassBenchmarks:
+
+    params = ([5, 10, 20],
+              [500, 1000])
+    param_names = ['n_qubits', 'depth']
+    timeout = 300
+
+    def setup(self, n_qubits, depth):
+        seed = 42
+        self.circuit = random_circuit(n_qubits, depth, measure=True,
+                                      conditional=True, reset=True, seed=seed,
+                                      max_operands=2)
+        self.basis_gates = ['rz', 'sx', 'x', 'cx', 'id', 'reset']
+        self.cmap = [[0, 1], [1, 0], [1, 2], [1, 6], [2, 1], [2, 3], [3, 2],
+                     [3, 4], [3, 8], [4, 3], [5, 6], [5, 10], [6, 1], [6, 5],
+                     [6, 7], [7, 6], [7, 8], [7, 12], [8, 3], [8, 7], [8, 9],
+                     [9, 8], [9, 14], [10, 5], [10, 11], [11, 10], [11, 12],
+                     [11, 16], [12, 7], [12, 11], [12, 13], [13, 12], [13, 14],
+                     [13, 18], [14, 9], [14, 13], [15, 16], [16, 11], [16, 15],
+                     [16, 17], [17, 16], [17, 18], [18, 13], [18, 17],
+                     [18, 19], [19, 18]]
+        self.coupling_map = CouplingMap(self.cmap)
+        self.transpiled_circuit = transpile(self.circuit,
+                                            basis_gates=self.basis_gates,
+                                            coupling_map=self.coupling_map,
+                                            optimization_level=1)
+        self.dag = circuit_to_dag(self.transpiled_circuit)
+        self.durations = InstructionDurations([
+            ("rz", None, 0),
+            ("id", None, 160),
+            ("sx", None, 160),
+            ("x", None, 160),
+            ("cx", None, 800),
+            ("measure", None, 3200),
+            ("reset", None, 3600),
+        ], dt=1e-9)
+        self.timed_dag = TimeUnitConversion(self.durations).run(self.dag)
+        _pass = ALAPSchedule(self.durations)
+        _pass.property_set['time_unit'] = "dt"
+        self.scheduled_dag = _pass.run(self.timed_dag)
+
+    def time_alap_schedule_pass(self, _, __):
+        _pass = ALAPSchedule(self.durations)
+        _pass.property_set['time_unit'] = "dt"
+        _pass.run(self.timed_dag)
+
+    def time_asap_schedule_pass(self, _, __):
+        _pass = ASAPSchedule(self.durations)
+        _pass.property_set['time_unit'] = "dt"
+        _pass.run(self.timed_dag)
+
+    def time_dynamical_decoupling_pass(self, _, __):
+        DynamicalDecoupling(self.durations, dd_sequence=[XGate(), XGate()]).run(self.scheduled_dag)

--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -78,4 +78,7 @@ class SchedulingPassBenchmarks:
         _pass.run(self.timed_dag)
 
     def time_dynamical_decoupling_pass(self, _, __):
-        DynamicalDecoupling(self.durations, dd_sequence=[XGate(), XGate()]).run(self.scheduled_dag)
+        DynamicalDecoupling(
+            self.durations,
+            dd_sequence=[XGate(), XGate()]
+        ).run(self.scheduled_dag)

--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -67,6 +67,9 @@ class SchedulingPassBenchmarks:
         _pass.property_set['time_unit'] = "dt"
         self.scheduled_dag = _pass.run(self.timed_dag)
 
+    def time_time_unit_conversion_pass(self, _, __):
+        TimeUnitConversion(self.durations).run(self.dag)
+
     def time_alap_schedule_pass(self, _, __):
         _pass = ALAPSchedule(self.durations)
         _pass.property_set['time_unit'] = "dt"

--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -19,7 +19,6 @@ import os
 
 from qiskit.compiler import transpile
 from qiskit import QuantumCircuit
-from qiskit.transpiler import InstructionDurations
 
 from .backends.fake_melbourne import FakeMelbourne
 from .utils import build_qv_model_circuit
@@ -156,14 +155,6 @@ class TranspilerLevelBenchmarks:
         large_qasm_path = os.path.join(self.qasm_path, 'test_eoh_qasm.qasm')
         self.large_qasm = QuantumCircuit.from_qasm_file(large_qasm_path)
         self.melbourne = FakeMelbourne()
-        self.durations = InstructionDurations([
-            ("u1", None, 0),
-            ("id", None, 160),
-            ("u2", None, 160),
-            ("u3", None, 320),
-            ("cx", None, 800),
-            ("measure", None, 3200),
-        ], dt=1e-9)
 
     def time_quantum_volume_transpile_50_x_20(self, transpiler_level):
         transpile(self.qv_50_x_20, basis_gates=self.basis_gates,
@@ -206,9 +197,3 @@ class TranspilerLevelBenchmarks:
     def track_depth_transpile_qv_14_x_14(self, transpiler_level):
         return transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
                          optimization_level=transpiler_level).depth()
-
-    def time_schedule_qv_14_x_14(self, transpiler_level):
-        transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
-                  optimization_level=transpiler_level,
-                  scheduling_method="alap",
-                  instruction_durations=self.durations)

--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -19,6 +19,7 @@ import os
 
 from qiskit.compiler import transpile
 from qiskit import QuantumCircuit
+from qiskit.transpiler import InstructionDurations
 
 from .backends.fake_melbourne import FakeMelbourne
 from .utils import build_qv_model_circuit
@@ -155,6 +156,14 @@ class TranspilerLevelBenchmarks:
         large_qasm_path = os.path.join(self.qasm_path, 'test_eoh_qasm.qasm')
         self.large_qasm = QuantumCircuit.from_qasm_file(large_qasm_path)
         self.melbourne = FakeMelbourne()
+        self.durations = InstructionDurations([
+            ("u1", None, 0),
+            ("id", None, 160),
+            ("u2", None, 160),
+            ("u3", None, 320),
+            ("cx", None, 800),
+            ("measure", None, 3200),
+        ], dt=1e-9)
 
     def time_quantum_volume_transpile_50_x_20(self, transpiler_level):
         transpile(self.qv_50_x_20, basis_gates=self.basis_gates,
@@ -197,3 +206,9 @@ class TranspilerLevelBenchmarks:
     def track_depth_transpile_qv_14_x_14(self, transpiler_level):
         return transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
                          optimization_level=transpiler_level).depth()
+
+    def time_schedule_qv_14_x_14(self, transpiler_level):
+        transpile(self.qv_14_x_14, self.melbourne, seed_transpiler=0,
+                  optimization_level=transpiler_level,
+                  scheduling_method="alap",
+                  instruction_durations=self.durations)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add benchmarks to track the time performance of circuit scheduling


### Details and comments
Add four tests, which benchmark TimeUnitConversion, ALAPSchedule, ASAPSchedule and DynamicalDecoupling passes. It would be a good time to start benchmarking those as rework on circuit scheduling passes is about to start.

