### PR TITLE
Update asv.conf.json to support recent changes

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -35,8 +35,8 @@
         "return-code=any python -mpip uninstall -y qiskit-ignis"
     ],
     "build_command": [
-        "pip install -U Cython",
-        "python setup.py build",
+        "pip install -U Cython setuptools-rust",
+        "python setup.py build_rust --release",
         "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
 
@@ -67,7 +67,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.6", "3.7", "3.8", "3.9"],
+    "pythons": ["3.7", "3.8", "3.9", "3.10"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the asv configuration to support two recent changes
in the terra repo. The first is updating the supported python version
list to reflect the current versions supported by terra. Python 3.6 is
no longer supported and python 3.10 is now supported. Additionally,
after Qiskit/qiskit-terra#7658 merged setuptools-rust and Rust are now
being used to build compiled extensions. While cython is still being
used, it's use will be removed soon with Qiskit/qiskit-terra#7702. This
commit updates the build configuration to build the rust extension and
then build a wheel from it instead of building the cython extension.

### Details and comments