### PR TITLE
Add qiskit-ibm-runtime client to be installable as an optional package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ visualization_extra = [
     "pygments>=2.4"
 ]
 
+ibm_extra = [
+    "qiskit-ibm-runtime>=0.1.1"
+]
 
 setup(
     name="qiskit",
@@ -104,12 +107,13 @@ setup(
     extras_require={
         'visualization': visualization_extra,
         'all': optimization_extra
-        + finance_extra + machine_learning_extra
-        + nature_extra + experiments_extra + visualization_extra,
+        + finance_extra + machine_learning_extra + nature_extra
+        + experiments_extra + visualization_extra + ibm_extra,
         'experiments': experiments_extra,
         'optimization': optimization_extra,
         'finance': finance_extra,
         'machine-learning': machine_learning_extra,
         'nature': nature_extra,
+        'ibm': ibm_extra,
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ visualization_extra = [
 ]
 
 ibm_extra = [
-    "qiskit-ibm-runtime>=0.1.1"
+    "qiskit-ibm-runtime>=0.2.0"
 ]
 
 setup(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This allows [qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime) to be installed when running `pip install qiskit[ibm]` or `pip install qiskit[all]`

### Details and comments
Fixes https://github.com/Qiskit/qiskit-ibm-runtime/issues/186

