### PR TITLE
Update `getting_started.rst`: Python 3.6 is no longer supported

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -9,7 +9,7 @@ Installation
 
 .. tabbed:: Start locally
 
-    Qiskit supports Python 3.6 or later. However, both Python and Qiskit are
+    Qiskit supports Python 3.7 or later. However, both Python and Qiskit are
     evolving ecosystems, and sometimes when new releases occur in one or the other,
     there can be problems with compatibility.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As discussed at https://github.com/Qiskit/qiskit-terra/pull/7295, the next release of Qiskit will no longer support Python 3.6.  This  PR updates the "getting started" documentation accordingly.

### Details and comments

There are still two lines that refer to Python 3.6 in `setup.py`, but I did not remove them, as I expected this to be updated automatically by qiskit-bot in the forthcoming "Bump Meta" PR (see e.g. #1063).