### PR TITLE
Add CODEOWNERS and Mergify configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# This file defines the set of people who are responsible for different parts of
+# the Qiskit metapackage code.
+#
+# Those assigned as owners of the whole repository are the core maintainers, who
+# (using privileges granted by other means) also have the power to make releases
+# of the metapackage.  These people can approve all pull requests.
+* @mtreinish @jakelishman @kevinhartman
+
+# More specialised rules override the global rule, so the core team need to be
+# respecified.
+
+/README.md @mtreinish @jakelishman @kevinhartman @HuangJunye @y4izus
+/docs      @mtreinish @jakelishman @kevinhartman @HuangJunye @y4izus

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,35 @@
+queue_rules:
+  - name: automerge
+    conditions: []  # No additional rules, because branch-protection does them.
+
+pull_request_rules:
+  - name: automatic merge on CI success and review
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=automerge
+      - label!=on hold
+      # GitHub branch-protection rules are automatically applied by mergify, so
+      # the queue can't actually merge things unless _all_ statuses are passed.
+      # This section is just a sanity check before the PR can enter the main
+      # queue.
+      - or:
+        - check-success=tests-python3.10-ubuntu-latest
+        - check-neutral=tests-python3.10-ubuntu-latest
+        - check-skipped=tests-python3.10-ubuntu-latest
+      - or:
+        - check-success=docs
+        - check-neutral=docs
+        - check-skipped=docs
+      - or:
+        - check-success=lint
+        - check-neutral=lint
+        - check-skipped=lint
+      - or:
+        - check-success=tutorials
+        - check-neutral=tutorials
+        - check-skipped=tutorials
+    actions:
+      queue:
+        name: automerge
+        method: squash


### PR DESCRIPTION
### Summary

This will let us restrict direct write access to the metapackage, while
empowering more people to approve and merge pull requests that they are
reponsible for maintaining.  Provided the mergify bot has the required
write access to create the merge commits, we can give non-administrator
code owners the "Triage" permission only, in order to add the
`automerge` label, and all commit merges will go through the Mergify
bot.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

I wasn't sure who to add in the various sections here, so open for more discussion.

The PR seems to be saying that Junye is insufficiently privileged (because he doesn't currently have write access), even though [the documentation says individually code owners only need to have read permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners):

> The people you choose as code owners must have read permissions for the repository.

This text changed in February of this year (probably about the same time the linter was introduced), but the linter on the file below seems to be complaining anyway.  I don't know which will actually take effect if we were to merge it.
