### PR TITLE
Add missing redirects for ignis tutorials

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,25 @@ ml_tutorials = [
     'index'
 ]
 
+dynamics_tutorials = [
+    "09_pulse_simulator_duffing_model",
+    "10_pulse_simulator_backend_model",
+]
+
+experiments_tutorials = [
+    "1_hamiltonian_and_gate_characterization",
+    "2_relaxation_and_decoherence",
+    "3_measurement_error_mitigation",
+    "4_randomized_benchmarking",
+    "5_quantum_volume",
+    "6_repetition_code",
+    "7_accreditation",
+    "8_tomography",
+    "9_entanglement_verification",
+    "index",
+]
+
+
 redirects = {
     "install": "getting_started.html",
 }
@@ -124,6 +143,11 @@ for tutorial in chemistry_tutorials:
 for tutorial in ml_tutorials:
     redirects["tutorials/machine_learning/%s" % tutorial] = "https://qiskit.org/documentation/machine-learning/tutorials/index.html"
 
+for tutorial in dynamics_tutorials:
+    redirects["tutorials/circuits_advanced/%s" % tutorial] = "https://qiskit.org/documentation/dynamics/tutorials/index.html"
+
+for tutorial in experiments_tutorials:
+    redirects["tutorials/noise/%s" % tutorial] = "https://qiskit.org/documentation/experiments/tutorials/index.html"
 
 nbsphinx_timeout = 300
 nbsphinx_execute = os.getenv('QISKIT_DOCS_BUILD_TUTORIALS', 'never')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1494 the index page for the removed ignis tutorials were removed,
this commit also needed to add redirects so that any saved links don't
404. This commit adds the missing redirects so that the tutorials are
redirected to approriate new package's documentation.

### Details and comments


