### PR TITLE
Add qiskit-neko documentation to other builds list

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -9,3 +9,4 @@
 /retworkx/**
 /stable/**
 /dynamics/**
+/neko/**


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the qiskit neko documentation to the other builds path.
This will let qiskit-neko manage publishing its own documentation to
https://qiskit.org/documentation/neko

### Details and comments