### PR TITLE
Change deprecated sphinx-panels to sphinx-design

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ extensions = [
     'sphinx_autodoc_typehints',
     'jupyter_sphinx',
     'nbsphinx',
-    'sphinx_panels',
+    'sphinx_design',
     'sphinx_reredirects'
 ]
 
@@ -200,7 +200,7 @@ numfig_format = {'table': 'Table %s'}
 # for a list of supported languages.
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # For Adding Locale
 locale_dirs = ['locale/']   # path is example but recommended.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pylatexenc>=1.4
 sphinx-automodapi
 jupyter
 jupyter-sphinx
-sphinx-panels
+sphinx-design
 sphinx-gallery
 matplotlib>=3.3.0
 pydot


### PR DESCRIPTION
### Summary

`sphinx-panels` is unmaintained, and suggests `sphinx-design` as a
largely drop-in replacement.  For our uses (only within Terra), we need
nothing more than to just change the dependency.

`sphinx-panels` was previously pinning us to Sphinx < 5, transitively.
With the new version of Sphinx, setting `language = None` is deprecated;
English is no longer implied by `None`, we have to set it (since, you
know, there are other languages in the world...).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

See also Qiskit/qiskit-terra#8242, Qiskit/qiskit-aer#1548.
