### PR TITLE
pep-0599 superseded by pep-0600

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -536,7 +536,7 @@ environment as all dependencies are available on these platforms.
 Tier 1 platforms are currently:
 
  * Linux x86_64 (distributions compatible with the
-   `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__
+   `manylinux 2014 <https://peps.python.org/pep-0600/>`__
    packaging specification.
  * macOS x86_64 (10.9 or newer)
  * Windows 64 bit
@@ -552,11 +552,11 @@ functioning Python environment.
 Tier 2 platforms are currently:
 
  * Linux i686 (distributions compatible with the
-   `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__ packaging
+   `manylinux 2014 <https://peps.python.org/pep-0600/>`__ packaging
    specification) for Python < 3.10
  * Windows 32 bit for Python < 3.10
  * Linux aarch64 (distributions compatible with the
-   `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__ packaging
+   `manylinux 2014 <https://peps.python.org/pep-0600/>`__ packaging
    specification)
 
 Tier 3
@@ -572,7 +572,7 @@ platforms are best effort only.
 Tier 3 platforms are currently:
 
  * Linux i686 (distributions compatible with the
-   `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__ packaging
+   `manylinux 2014 <https://peps.python.org/pep-0600/>`__ packaging
    specification) for Python >= 3.10
  * Windows 32 bit for Python >= 3.10
  * macOS arm64 (10.15 or newer)


### PR DESCRIPTION
Issue reported in [Qiskit Slack](https://qiskit.slack.com/archives/CSUDA6KM1/p1657705406991269)

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
pep-0599 referenced in manylinux 2014 link superseded by pep-0600
Issue reported in [Qiskit Slack](https://qiskit.slack.com/archives/CSUDA6KM1/p1657705406991269)


### Details and comments
Updated doc to ref pep-0600
Trivial, did not put in any relnote for this

