### PR TITLE
Update tab syntax for sphinx-design

### DIFF
--- a/docs/contributing_to_qiskit.rst
+++ b/docs/contributing_to_qiskit.rst
@@ -696,43 +696,45 @@ from system-wide packages. This way, we avoid inadvertently becoming dependent o
 particular system configuration. For developers, this also makes it easy to maintain multiple
 environments (e.g. one per supported Python version, for older versions of Qiskit, etc.).
 
-.. tabbed:: Python venv
+.. tab-set::
 
-   All Python versions supported by Qiskit include built-in virtual environment module
-   `venv <https://docs.python.org/3/tutorial/venv.html>`__.
+    .. tab-item:: Python venv
 
-   Start by creating a new virtual environment with ``venv``. The resulting
-   environment will use the same version of Python that created it and will not inherit installed
-   system-wide packages by default. The specified folder will be created and is used to hold the environment's
-   installation. It can be placed anywhere. For more detail, see the official Python documentation,
-   `Creation of virtual environments <https://docs.python.org/3/library/venv.html>`__.
+       All Python versions supported by Qiskit include built-in virtual environment module
+       `venv <https://docs.python.org/3/tutorial/venv.html>`__.
 
-   .. code-block:: sh
+       Start by creating a new virtual environment with ``venv``. The resulting
+       environment will use the same version of Python that created it and will not inherit installed
+       system-wide packages by default. The specified folder will be created and is used to hold the environment's
+       installation. It can be placed anywhere. For more detail, see the official Python documentation,
+       `Creation of virtual environments <https://docs.python.org/3/library/venv.html>`__.
 
-      python3 -m venv ~/.venvs/qiskit-dev
+       .. code-block:: sh
 
-   Activate the environment by invoking the appropriate activation script for your system, which can
-   be found within the environment folder. For example, for bash/zsh:
+          python3 -m venv ~/.venvs/qiskit-dev
 
-   .. code-block:: sh
+       Activate the environment by invoking the appropriate activation script for your system, which can
+       be found within the environment folder. For example, for bash/zsh:
 
-      source ~/.venvs/qiskit-dev/bin/activate
+       .. code-block:: sh
 
-   Upgrade pip within the environment to ensure Qiskit dependencies installed in the subsequent sections
-   can be located for your system.
+          source ~/.venvs/qiskit-dev/bin/activate
 
-   .. code-block:: sh
+       Upgrade pip within the environment to ensure Qiskit dependencies installed in the subsequent sections
+       can be located for your system.
 
-      pip install -U pip
+       .. code-block:: sh
 
-.. tabbed:: Conda
+          pip install -U pip
 
-   For Conda users, a new environment can be created as follows.
+    .. tab-item:: Conda
 
-   .. code-block:: sh
+       For Conda users, a new environment can be created as follows.
 
-      conda create -y -n QiskitDevenv python=3
-      conda activate QiskitDevenv
+       .. code-block:: sh
+
+          conda create -y -n QiskitDevenv python=3
+          conda activate QiskitDevenv
 
 
 .. _install-qiskit-terra:
@@ -832,84 +834,86 @@ using. Since Aer is a compiled C++ program with a Python interface, there are
 non-Python dependencies for building the Aer binary which can't be installed
 universally depending on operating system.
 
-.. tabbed:: Linux
+.. tab-set::
 
-   3. Install compiler requirements.
+    .. tab-item:: Linux
 
-      Building Aer requires a C++ compiler and development headers.
+       3. Install compiler requirements.
 
-      If you're using Fedora or an equivalent Linux distribution,
-      install using:
+          Building Aer requires a C++ compiler and development headers.
 
-      .. code:: sh
+          If you're using Fedora or an equivalent Linux distribution,
+          install using:
 
-         dnf install @development-tools
+          .. code:: sh
 
-      For Ubuntu/Debian install it using:
+             dnf install @development-tools
 
-      .. code:: sh
+          For Ubuntu/Debian install it using:
 
-         apt-get install build-essential
+          .. code:: sh
 
-   4. Install OpenBLAS development headers.
+             apt-get install build-essential
 
-      If you're using Fedora or an equivalent Linux distribution,
-      install using:
+       4. Install OpenBLAS development headers.
 
-      .. code:: sh
+          If you're using Fedora or an equivalent Linux distribution,
+          install using:
 
-         dnf install openblas-devel
+          .. code:: sh
 
-      For Ubuntu/Debian install it using:
+             dnf install openblas-devel
 
-      .. code:: sh
+          For Ubuntu/Debian install it using:
 
-         apt-get install libopenblas-dev
+          .. code:: sh
+
+             apt-get install libopenblas-dev
 
 
-.. tabbed:: macOS
+    .. tab-item:: macOS
 
 
-   3. Install dependencies.
+       3. Install dependencies.
 
-      To use the `Clang <https://clang.llvm.org/>`__ compiler on macOS, you need to install
-      an extra library for supporting `OpenMP <https://www.openmp.org/>`__.  You can use `brew <https://brew.sh/>`__
-      to install this and other dependencies.
+          To use the `Clang <https://clang.llvm.org/>`__ compiler on macOS, you need to install
+          an extra library for supporting `OpenMP <https://www.openmp.org/>`__.  You can use `brew <https://brew.sh/>`__
+          to install this and other dependencies.
 
-      .. code:: sh
+          .. code:: sh
 
-         brew install libomp
+             brew install libomp
 
-   4. Then install a BLAS implementation; `OpenBLAS <https://www.openblas.net/>`__
-      is the default choice.
+       4. Then install a BLAS implementation; `OpenBLAS <https://www.openblas.net/>`__
+          is the default choice.
 
-      .. code:: sh
+          .. code:: sh
 
-         brew install openblas
+             brew install openblas
 
-      Next, install ``Xcode Command Line Tools``.
+          Next, install ``Xcode Command Line Tools``.
 
-      .. code:: sh
+          .. code:: sh
 
-         xcode-select --install
+             xcode-select --install
 
-.. tabbed:: Windows
+    .. tab-item:: Windows
 
-   On Windows you need to use `Anaconda3 <https://www.anaconda.com/distribution/#windows>`__
-   or `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`__ to install all the
-   dependencies.
+       On Windows you need to use `Anaconda3 <https://www.anaconda.com/distribution/#windows>`__
+       or `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`__ to install all the
+       dependencies.
 
-   3. Install compiler requirements.
+       3. Install compiler requirements.
 
-      .. code:: sh
+          .. code:: sh
 
-         conda install --update-deps vs2017_win-64 vs2017_win-32 msvc_runtime
+             conda install --update-deps vs2017_win-64 vs2017_win-32 msvc_runtime
 
-   4. Install binary and build dependencies.
+       4. Install binary and build dependencies.
 
-      .. code:: sh
+          .. code:: sh
 
-         conda install --update-deps -c conda-forge -y openblas cmake
+             conda install --update-deps -c conda-forge -y openblas cmake
 
 
 5. Build and install qiskit-aer directly

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,509 +7,512 @@ Getting started
 Installation
 ============
 
-.. tabbed:: Start locally
+.. tab-set::
 
-    Qiskit supports Python 3.7 or later. However, both Python and Qiskit are
-    evolving ecosystems, and sometimes when new releases occur in one or the other,
-    there can be problems with compatibility.
+    .. tab-item:: Start locally
 
-    We recommend installing `Anaconda <https://www.anaconda.com/download/>`__, a
-    cross-platform Python distribution for scientific computing. Jupyter,
-    included in Anaconda, is recommended for interacting with Qiskit.
+        Qiskit supports Python 3.7 or later. However, both Python and Qiskit are
+        evolving ecosystems, and sometimes when new releases occur in one or the other,
+        there can be problems with compatibility.
 
-    We recommend using Python virtual environments to cleanly separate Qiskit from
-    other applications and improve your experience.
+        We recommend installing `Anaconda <https://www.anaconda.com/download/>`__, a
+        cross-platform Python distribution for scientific computing. Jupyter,
+        included in Anaconda, is recommended for interacting with Qiskit.
 
-    The simplest way to use environments is by using the ``conda`` command,
-    included with Anaconda. A Conda environment allows you to specify a specific
-    version of Python and set of libraries. Open a terminal window in the directory
-    where you want to work.
+        We recommend using Python virtual environments to cleanly separate Qiskit from
+        other applications and improve your experience.
 
-    It is preferred that you use the Anaconda prompt installed with Anaconda.
-    All you have to do is create a virtual environment inside Anaconda and activate the environment.
-    These commands can be run in the Anaconda prompt irrespective of Windows or Linux machine.
+        The simplest way to use environments is by using the ``conda`` command,
+        included with Anaconda. A Conda environment allows you to specify a specific
+        version of Python and set of libraries. Open a terminal window in the directory
+        where you want to work.
 
-    Create a minimal environment with only Python installed in it.
+        It is preferred that you use the Anaconda prompt installed with Anaconda.
+        All you have to do is create a virtual environment inside Anaconda and activate the environment.
+        These commands can be run in the Anaconda prompt irrespective of Windows or Linux machine.
 
-    .. code:: sh
+        Create a minimal environment with only Python installed in it.
 
-        conda create -n ENV_NAME python=3
+        .. code:: sh
 
-    Activate your new environment.
+            conda create -n ENV_NAME python=3
 
-    .. code:: sh
+        Activate your new environment.
 
-        conda activate ENV_NAME
+        .. code:: sh
 
+            conda activate ENV_NAME
 
-    Next, install the Qiskit package.
 
-    .. code:: sh
+        Next, install the Qiskit package.
 
-        pip install qiskit
+        .. code:: sh
 
-    If the packages were installed correctly, you can run ``conda list`` to see the active
-    packages in your virtual environment.
+            pip install qiskit
 
-    If you intend to use visualization functionality or Jupyter notebooks it is
-    recommended to install Qiskit with the extra ``visualization`` support:
+        If the packages were installed correctly, you can run ``conda list`` to see the active
+        packages in your virtual environment.
 
-    .. code:: sh
+        If you intend to use visualization functionality or Jupyter notebooks it is
+        recommended to install Qiskit with the extra ``visualization`` support:
 
-        pip install qiskit[visualization]
+        .. code:: sh
 
-    It is worth pointing out that if you're a zsh user (which is the default shell on newer
-    versions of macOS), you'll need to put ``qiskit[visualization]`` in quotes:
+            pip install qiskit[visualization]
 
-    .. code:: sh
+        It is worth pointing out that if you're a zsh user (which is the default shell on newer
+        versions of macOS), you'll need to put ``qiskit[visualization]`` in quotes:
 
-        pip install 'qiskit[visualization]'
+        .. code:: sh
 
+            pip install 'qiskit[visualization]'
 
-.. tabbed:: Start on the cloud
+    .. tab-item:: Start on the cloud
 
-    The following cloud vendors have Qiskit pre-installed in their environments:
+        The following cloud vendors have Qiskit pre-installed in their environments:
 
-   .. raw:: html
+       .. raw:: html
 
-      <div id="tutorial-cards-container">
-      <hr class="tutorials-hr">
-      <div class="row">
-      <div id="tutorial-cards">
-      <div class="list">
+          <div id="tutorial-cards-container">
+          <hr class="tutorials-hr">
+          <div class="row">
+          <div id="tutorial-cards">
+          <div class="list">
 
-   .. customcarditem::
-      :header: IBM Quantum Lab
-      :card_description: Build quantum applications and experiments with Qiskit in a cloud programming environment.
-      :image: _static/ibm_qlab.png
-      :link: https://quantum-computing.ibm.com/
+       .. customcarditem::
+          :header: IBM Quantum Lab
+          :card_description: Build quantum applications and experiments with Qiskit in a cloud programming environment.
+          :image: _static/ibm_qlab.png
+          :link: https://quantum-computing.ibm.com/
 
-   .. customcarditem::
-      :header: Strangeworks
-      :card_description: A platform that enables users and organizations to easily apply quantum computing to their most pressing problems and research.
-      :image: _static/strangeworks.png
-      :link: https://strangeworks.com/
+       .. customcarditem::
+          :header: Strangeworks
+          :card_description: A platform that enables users and organizations to easily apply quantum computing to their most pressing problems and research.
+          :image: _static/strangeworks.png
+          :link: https://strangeworks.com/
 
-   .. raw:: html
+       .. raw:: html
 
-      </div>
-      <div class="pagination d-flex justify-content-center"></div>
-      </div>
-      </div>
-      </div>
+          </div>
+          <div class="pagination d-flex justify-content-center"></div>
+          </div>
+          </div>
+          </div>
 
-.. tabbed:: Install from source
+    .. tab-item:: Install from source
 
-   Installing the elements from source allows you to access the most recently
-   updated version of Qiskit instead of using the version in the Python Package
-   Index (PyPI) repository. This will give you the ability to inspect and extend
-   the latest version of the Qiskit code more efficiently.
+       Installing the elements from source allows you to access the most recently
+       updated version of Qiskit instead of using the version in the Python Package
+       Index (PyPI) repository. This will give you the ability to inspect and extend
+       the latest version of the Qiskit code more efficiently.
 
-   When installing the elements and components from source, by default their
-   ``development`` version (which corresponds to the ``master`` git branch) will
-   be used, as opposed to the ``stable`` version (which contains the same codebase
-   as the published ``pip`` packages). Since the ``development`` versions of an
-   element or component usually include new features and changes, they generally
-   require using the ``development`` version of the rest of the items as well.
+       When installing the elements and components from source, by default their
+       ``development`` version (which corresponds to the ``master`` git branch) will
+       be used, as opposed to the ``stable`` version (which contains the same codebase
+       as the published ``pip`` packages). Since the ``development`` versions of an
+       element or component usually include new features and changes, they generally
+       require using the ``development`` version of the rest of the items as well.
 
-   .. note::
+       .. note::
 
-   The Terra and Aer packages both require a compiler to build from source before
-   you can install. Ignis, Aqua, and the IBM Quantum Provider backend
-   do not require a compiler.
+       The Terra and Aer packages both require a compiler to build from source before
+       you can install. Ignis, Aqua, and the IBM Quantum Provider backend
+       do not require a compiler.
 
-   Installing elements from source requires the following order of installation to
-   prevent installing versions of elements that may be lower than those desired if the
-   ``pip`` version is behind the source versions:
+       Installing elements from source requires the following order of installation to
+       prevent installing versions of elements that may be lower than those desired if the
+       ``pip`` version is behind the source versions:
 
-   #. :ref:`qiskit-terra <install-qiskit-terra>`
-   #. :ref:`qiskit-aer <install-qiskit-aer>`
-   #. :ref:`qiskit-ibmq-provider <install-qiskit-ibmq-provider>`
-      (if you want to connect to the IBM Quantum devices or online
-      simulator)
+       #. :ref:`qiskit-terra <install-qiskit-terra>`
+       #. :ref:`qiskit-aer <install-qiskit-aer>`
+       #. :ref:`qiskit-ibmq-provider <install-qiskit-ibmq-provider>`
+          (if you want to connect to the IBM Quantum devices or online
+          simulator)
 
-   To work with several components and elements simultaneously, use the following
-   steps for each element.
+       To work with several components and elements simultaneously, use the following
+       steps for each element.
 
-   .. note::
+       .. note::
 
-      Due to the use of namespace packaging in Python, care must be taken in how you
-      install packages. If you're planning to install any element from source, do not
-      use the ``qiskit`` meta-package. Also, follow this guide and use a separate virtual
-      environment for development. If you do choose to mix an existing installation
-      with your development, refer to
-      https://github.com/pypa/sample-namespace-packages/blob/master/table.md
-      for the set of combinations of installation methods that work together.
+          Due to the use of namespace packaging in Python, care must be taken in how you
+          install packages. If you're planning to install any element from source, do not
+          use the ``qiskit`` meta-package. Also, follow this guide and use a separate virtual
+          environment for development. If you do choose to mix an existing installation
+          with your development, refer to
+          https://github.com/pypa/sample-namespace-packages/blob/master/table.md
+          for the set of combinations of installation methods that work together.
 
-   .. raw:: html
+       .. raw:: html
 
-      <h3>Set up the Virtual Development Environment</h3>
+          <h3>Set up the Virtual Development Environment</h3>
 
-   .. code-block:: sh
+       .. code-block:: sh
 
-      conda create -y -n QiskitDevenv python=3
-      conda activate QiskitDevenv
+          conda create -y -n QiskitDevenv python=3
+          conda activate QiskitDevenv
 
-   .. _install-qiskit-terra:
+       .. _install-qiskit-terra:
 
-   .. raw:: html
+       .. raw:: html
 
-      <h2>Installing Terra from Source</h2>
+          <h2>Installing Terra from Source</h2>
 
-   Installing from source requires that you have a C++ compiler on your system that supports
-   C++11.
+       Installing from source requires that you have a C++ compiler on your system that supports
+       C++11.
 
 
-   .. tabbed:: Compiler for Linux
+       .. tab-set::
 
-      On most Linux platforms, the necessary GCC compiler is already installed.
+          .. tab-item:: Compiler for Linux
 
-   .. tabbed:: Compiler for macOS
+             On most Linux platforms, the necessary GCC compiler is already installed.
 
-      If you use macOS, you can install the Clang compiler by installing XCode.
-      Check if you have XCode and Clang installed by opening a terminal window and entering the
-      following.
+          .. tab-item:: Compiler for macOS
 
-      .. code:: sh
+             If you use macOS, you can install the Clang compiler by installing XCode.
+             Check if you have XCode and Clang installed by opening a terminal window and entering the
+             following.
 
-         clang --version
+             .. code:: sh
 
-      Install XCode and Clang by using the following command.
+                clang --version
 
-      .. code:: sh
+             Install XCode and Clang by using the following command.
 
-         xcode-select --install
+             .. code:: sh
 
-   .. tabbed:: Compiler for Windows
+                xcode-select --install
 
-      On Windows, it is easiest to install the Visual C++ compiler from the
-      `Build Tools for Visual Studio 2019 <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019>`__.
-      You can instead install Visual Studio version 2015 or 2017, making sure to select the
-      options for installing the C++ compiler.
+          .. tab-item:: Compiler for Windows
 
+             On Windows, it is easiest to install the Visual C++ compiler from the
+             `Build Tools for Visual Studio 2019 <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019>`__.
+             You can instead install Visual Studio version 2015 or 2017, making sure to select the
+             options for installing the C++ compiler.
 
-   Once the compilers are installed, you are ready to install Qiskit Terra.
 
-   1. Clone the Terra repository.
+       Once the compilers are installed, you are ready to install Qiskit Terra.
 
-      .. code:: sh
+       1. Clone the Terra repository.
 
-         git clone https://github.com/Qiskit/qiskit-terra.git
+          .. code:: sh
 
-   2. Cloning the repository creates a local folder called ``qiskit-terra``.
+             git clone https://github.com/Qiskit/qiskit-terra.git
 
-      .. code:: sh
+       2. Cloning the repository creates a local folder called ``qiskit-terra``.
 
-         cd qiskit-terra
+          .. code:: sh
 
-   3. Install the Python requirements libraries from your ``qiskit-terra`` directory.
+             cd qiskit-terra
 
-      .. code:: sh
+       3. Install the Python requirements libraries from your ``qiskit-terra`` directory.
 
-         pip install cython
+          .. code:: sh
 
-   4. If you want to run tests or linting checks, install the developer requirements.
+             pip install cython
 
-      .. code:: sh
+       4. If you want to run tests or linting checks, install the developer requirements.
 
-         pip install -r requirements-dev.txt
+          .. code:: sh
 
-   5. Install ``qiskit-terra``.
+             pip install -r requirements-dev.txt
 
-      .. code:: sh
+       5. Install ``qiskit-terra``.
 
-         pip install .
+          .. code:: sh
 
-   If you want to install it in editable mode, meaning that code changes to the
-   project don't require a reinstall to be applied, you can do this with:
+             pip install .
 
-   .. code:: sh
+       If you want to install it in editable mode, meaning that code changes to the
+       project don't require a reinstall to be applied, you can do this with:
 
-      pip install -e .
+       .. code:: sh
 
-   You can then run the code examples after installing Terra. You can
-   run the example with the following command.
+          pip install -e .
 
-   .. code:: sh
+       You can then run the code examples after installing Terra. You can
+       run the example with the following command.
 
-      python examples/python/using_qiskit_terra_level_0.py
+       .. code:: sh
 
+          python examples/python/using_qiskit_terra_level_0.py
 
-   .. note::
 
-      If you do not intend to install any other components, qiskit-terra will
-      emit a ``RuntimeWarning`` warning that both qiskit-aer and
-      qiskit-ibmq-provider are not installed. This is done because
-      users commonly intend to use the additional elements,
-      but do not realize they are not installed, or that the installation
-      of either Aer or the IBM Quantum Provider failed for some reason. If you wish
-      to suppress these warnings, add::
+       .. note::
 
-         import warnings
-         warnings.filterwarnings('ignore', category=RuntimeWarning,
-                                 module='qiskit')
+          If you do not intend to install any other components, qiskit-terra will
+          emit a ``RuntimeWarning`` warning that both qiskit-aer and
+          qiskit-ibmq-provider are not installed. This is done because
+          users commonly intend to use the additional elements,
+          but do not realize they are not installed, or that the installation
+          of either Aer or the IBM Quantum Provider failed for some reason. If you wish
+          to suppress these warnings, add::
 
-      before any ``qiskit`` imports in your code. This will suppress the
-      warning about the missing qiskit-aer and qiskit-ibmq-provider, but
-      will continue to display any other warnings from qiskit or other packages.
+             import warnings
+             warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                     module='qiskit')
 
-   .. _install-qiskit-aer:
+          before any ``qiskit`` imports in your code. This will suppress the
+          warning about the missing qiskit-aer and qiskit-ibmq-provider, but
+          will continue to display any other warnings from qiskit or other packages.
 
-   .. raw:: html
+       .. _install-qiskit-aer:
 
-      <h2>Installing Aer from Source</h2>
+       .. raw:: html
 
-   1. Clone the Aer repository.
+          <h2>Installing Aer from Source</h2>
 
-      .. code:: sh
+       1. Clone the Aer repository.
 
-         git clone https://github.com/Qiskit/qiskit-aer
+          .. code:: sh
 
-   2. Install build requirements.
+             git clone https://github.com/Qiskit/qiskit-aer
 
-      .. code:: sh
+       2. Install build requirements.
 
-         pip install cmake scikit-build cython
+          .. code:: sh
 
-   After this, the steps to install Aer depend on which operating system you are
-   using. Since Aer is a compiled C++ program with a Python interface, there are
-   non-Python dependencies for building the Aer binary which can't be installed
-   universally depending on operating system.
+             pip install cmake scikit-build cython
 
+       After this, the steps to install Aer depend on which operating system you are
+       using. Since Aer is a compiled C++ program with a Python interface, there are
+       non-Python dependencies for building the Aer binary which can't be installed
+       universally depending on operating system.
 
-   .. dropdown:: Linux
 
-      3. Install compiler requirements.
+       .. dropdown:: Linux
 
-         Building Aer requires a C++ compiler and development headers.
+          3. Install compiler requirements.
 
-         If you're using Fedora or an equivalent Linux distribution,
-         install using:
+             Building Aer requires a C++ compiler and development headers.
 
-         .. code:: sh
+             If you're using Fedora or an equivalent Linux distribution,
+             install using:
 
-               dnf install @development-tools
+             .. code:: sh
 
-         For Ubuntu/Debian install it using:
+                   dnf install @development-tools
 
-         .. code:: sh
+             For Ubuntu/Debian install it using:
 
-               apt-get install build-essential
+             .. code:: sh
 
-      4. Install OpenBLAS development headers.
+                   apt-get install build-essential
 
-         If you're using Fedora or an equivalent Linux distribution,
-         install using:
+          4. Install OpenBLAS development headers.
 
-         .. code:: sh
+             If you're using Fedora or an equivalent Linux distribution,
+             install using:
 
-               dnf install openblas-devel
+             .. code:: sh
 
-         For Ubuntu/Debian install it using:
+                   dnf install openblas-devel
 
-         .. code:: sh
+             For Ubuntu/Debian install it using:
 
-               apt-get install libopenblas-dev
+             .. code:: sh
 
+                   apt-get install libopenblas-dev
 
-   .. dropdown:: macOS
 
-      3. Install dependencies.
+       .. dropdown:: macOS
 
-         To use the `Clang <https://clang.llvm.org/>`__ compiler on macOS, you need to install
-         an extra library for supporting `OpenMP <https://www.openmp.org/>`__.  You can use `brew <https://brew.sh/>`__
-         to install this and other dependencies.
+          3. Install dependencies.
 
-         .. code:: sh
+             To use the `Clang <https://clang.llvm.org/>`__ compiler on macOS, you need to install
+             an extra library for supporting `OpenMP <https://www.openmp.org/>`__.  You can use `brew <https://brew.sh/>`__
+             to install this and other dependencies.
 
-               brew install libomp
+             .. code:: sh
 
-      4. Then install a BLAS implementation; `OpenBLAS <https://www.openblas.net/>`__
-         is the default choice.
+                   brew install libomp
 
-         .. code:: sh
+          4. Then install a BLAS implementation; `OpenBLAS <https://www.openblas.net/>`__
+             is the default choice.
 
-               brew install openblas
+             .. code:: sh
 
-         Next, install ``Xcode Command Line Tools``.
+                   brew install openblas
 
-         .. code:: sh
+             Next, install ``Xcode Command Line Tools``.
 
-               xcode-select --install
+             .. code:: sh
 
-   .. dropdown:: Windows
+                   xcode-select --install
 
-      On Windows you need to use `Anaconda3 <https://www.anaconda.com/distribution/#windows>`__
-      or `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`__ to install all the
-      dependencies.
+       .. dropdown:: Windows
 
-      3. Install compiler requirements.
+          On Windows you need to use `Anaconda3 <https://www.anaconda.com/distribution/#windows>`__
+          or `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`__ to install all the
+          dependencies.
 
-         .. code:: sh
+          3. Install compiler requirements.
 
-               conda install --update-deps vs2017_win-64 vs2017_win-32 msvc_runtime
+             .. code:: sh
 
-   Qiskit Aer is a high performance simulator framework for quantum circuits. It
-   provides `several backends <apidoc/aer_provider.html#simulator-backends>`__
-   to achieve different simulation goals.
+                   conda install --update-deps vs2017_win-64 vs2017_win-32 msvc_runtime
 
-         .. code:: sh
+       Qiskit Aer is a high performance simulator framework for quantum circuits. It
+       provides `several backends <apidoc/aer_provider.html#simulator-backends>`__
+       to achieve different simulation goals.
 
-               conda install --update-deps -c conda-forge -y openblas cmake
+             .. code:: sh
 
+                   conda install --update-deps -c conda-forge -y openblas cmake
 
-   5. Build and install qiskit-aer directly
 
-      If you have pip <19.0.0 installed and your environment doesn't require a
-      custom build, run:
+       5. Build and install qiskit-aer directly
 
-      .. code:: sh
+          If you have pip <19.0.0 installed and your environment doesn't require a
+          custom build, run:
 
-         cd qiskit-aer
-         pip install .
+          .. code:: sh
 
-      This will both build the binaries and install Aer.
+             cd qiskit-aer
+             pip install .
 
-      Alternatively, if you have a newer pip installed, or have some custom requirement,
-      you can build a Python wheel manually.
+          This will both build the binaries and install Aer.
 
-      .. code:: sh
+          Alternatively, if you have a newer pip installed, or have some custom requirement,
+          you can build a Python wheel manually.
 
-         cd qiskit-aer
-         python ./setup.py bdist_wheel
+          .. code:: sh
 
-      If you need to set a custom option during the wheel build, refer to
-      :ref:`aer_wheel_build_options`.
+             cd qiskit-aer
+             python ./setup.py bdist_wheel
 
-      After you build the Python wheel, it will be stored in the ``dist/`` dir in the
-      Aer repository. The exact version will depend
+          If you need to set a custom option during the wheel build, refer to
+          :ref:`aer_wheel_build_options`.
 
-      .. code:: sh
+          After you build the Python wheel, it will be stored in the ``dist/`` dir in the
+          Aer repository. The exact version will depend
 
-         cd dist
-         pip install qiskit_aer-*.whl
+          .. code:: sh
 
-      The exact filename of the output wheel file depends on the current version of
-      Aer under development.
+             cd dist
+             pip install qiskit_aer-*.whl
 
-   .. _aer_wheel_build_options:
+          The exact filename of the output wheel file depends on the current version of
+          Aer under development.
 
-   .. raw:: html
+       .. _aer_wheel_build_options:
 
-      <h4>Custom options</h4>
+       .. raw:: html
 
-   The Aer build system uses `scikit-build <https://scikit-build.readthedocs.io/en/latest/index.html>`__
-   to run the compilation when building it with the Python interface. It acts as an interface for
-   `setuptools <https://setuptools.readthedocs.io/en/latest/>`__ to call `CMake <https://cmake.org/>`__
-   and compile the binaries for your local system.
+          <h4>Custom options</h4>
 
-   Due to the complexity of compiling the binaries, you may need to pass options
-   to a certain part of the build process. The way to pass variables is:
+       The Aer build system uses `scikit-build <https://scikit-build.readthedocs.io/en/latest/index.html>`__
+       to run the compilation when building it with the Python interface. It acts as an interface for
+       `setuptools <https://setuptools.readthedocs.io/en/latest/>`__ to call `CMake <https://cmake.org/>`__
+       and compile the binaries for your local system.
 
-   .. code:: sh
+       Due to the complexity of compiling the binaries, you may need to pass options
+       to a certain part of the build process. The way to pass variables is:
 
-      python setup.py bdist_wheel [skbuild_opts] [-- [cmake_opts] [-- build_tool_opts]]
+       .. code:: sh
 
-   where the elements within square brackets `[]` are optional, and
-   ``skbuild_opts``, ``cmake_opts``, ``build_tool_opts`` are to be replaced by
-   flags of your choice. A list of *CMake* options is available here:
-   https://cmake.org/cmake/help/v3.6/manual/cmake.1.html#options. For
-   example, you could run something like:
+          python setup.py bdist_wheel [skbuild_opts] [-- [cmake_opts] [-- build_tool_opts]]
 
-   .. code:: sh
+       where the elements within square brackets `[]` are optional, and
+       ``skbuild_opts``, ``cmake_opts``, ``build_tool_opts`` are to be replaced by
+       flags of your choice. A list of *CMake* options is available here:
+       https://cmake.org/cmake/help/v3.6/manual/cmake.1.html#options. For
+       example, you could run something like:
 
-      python setup.py bdist_wheel -- -- -j8
+       .. code:: sh
 
-   This is passing the flag `-j8` to the underlying build system (which in this
-   case is `Automake <https://www.gnu.org/software/automake/>`__), telling it that you want
-   to build in parallel using 8 processes.
+          python setup.py bdist_wheel -- -- -j8
 
-   For example, a common use case for these flags on linux is to specify a
-   specific version of the C++ compiler to use (normally if the default is too
-   old):
+       This is passing the flag `-j8` to the underlying build system (which in this
+       case is `Automake <https://www.gnu.org/software/automake/>`__), telling it that you want
+       to build in parallel using 8 processes.
 
-   .. code:: sh
+       For example, a common use case for these flags on linux is to specify a
+       specific version of the C++ compiler to use (normally if the default is too
+       old):
 
-      python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7
+       .. code:: sh
 
-   which will tell CMake to use the g++-7 command instead of the default g++ when
-   compiling Aer.
+          python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7
 
-   Another common use case for this, depending on your environment, is that you may
-   need to specify your platform name and turn off static linking.
+       which will tell CMake to use the g++-7 command instead of the default g++ when
+       compiling Aer.
 
-   .. code:: sh
+       Another common use case for this, depending on your environment, is that you may
+       need to specify your platform name and turn off static linking.
 
-      python setup.py bdist_wheel --plat-name macosx-10.9-x86_64 \
-      -- -DSTATIC_LINKING=False -- -j8
+       .. code:: sh
 
-   Here ``--plat-name`` is a flag to setuptools, to specify the platform name to
-   use in the package metadata, ``-DSTATIC_LINKING`` is a flag for using CMake
-   to disable static linking, and ``-j8`` is a flag for using Automake to use
-   8 processes for compilation.
+          python setup.py bdist_wheel --plat-name macosx-10.9-x86_64 \
+          -- -DSTATIC_LINKING=False -- -j8
 
-   A list of common options depending on platform are:
+       Here ``--plat-name`` is a flag to setuptools, to specify the platform name to
+       use in the package metadata, ``-DSTATIC_LINKING`` is a flag for using CMake
+       to disable static linking, and ``-j8`` is a flag for using Automake to use
+       8 processes for compilation.
 
-   +--------+------------+----------------------+---------------------------------------------+
-   |Platform| Tool       | Option               | Use Case                                    |
-   +========+============+======================+=============================================+
-   | All    | Automake   | -j                   | Followed by a number, sets the number of    |
-   |        |            |                      | processes to use for compilation.           |
-   +--------+------------+----------------------+---------------------------------------------+
-   | Linux  | CMake      | -DCMAKE_CXX_COMPILER | Used to specify a specific C++ compiler;    |
-   |        |            |                      | this is often needed if your default g++ is |
-   |        |            |                      | too old.                                    |
-   +--------+------------+----------------------+---------------------------------------------+
-   | OSX    | setuptools | --plat-name          | Used to specify the platform name in the    |
-   |        |            |                      | output Python package.                      |
-   +--------+------------+----------------------+---------------------------------------------+
-   | OSX    | CMake      | -DSTATIC_LINKING     | Used to specify whether or not              |
-   |        |            |                      | static linking should be used.              |
-   +--------+------------+----------------------+---------------------------------------------+
+       A list of common options depending on platform are:
 
-   .. note::
-      Some of these options are not platform-specific. These particular platforms are listed
-      because they are commonly used in the environment. Refer to the
-      tool documentation for more information.
+       +--------+------------+----------------------+---------------------------------------------+
+       |Platform| Tool       | Option               | Use Case                                    |
+       +========+============+======================+=============================================+
+       | All    | Automake   | -j                   | Followed by a number, sets the number of    |
+       |        |            |                      | processes to use for compilation.           |
+       +--------+------------+----------------------+---------------------------------------------+
+       | Linux  | CMake      | -DCMAKE_CXX_COMPILER | Used to specify a specific C++ compiler;    |
+       |        |            |                      | this is often needed if your default g++ is |
+       |        |            |                      | too old.                                    |
+       +--------+------------+----------------------+---------------------------------------------+
+       | OSX    | setuptools | --plat-name          | Used to specify the platform name in the    |
+       |        |            |                      | output Python package.                      |
+       +--------+------------+----------------------+---------------------------------------------+
+       | OSX    | CMake      | -DSTATIC_LINKING     | Used to specify whether or not              |
+       |        |            |                      | static linking should be used.              |
+       +--------+------------+----------------------+---------------------------------------------+
 
-   .. _install-qiskit-ibmq-provider:
+       .. note::
+          Some of these options are not platform-specific. These particular platforms are listed
+          because they are commonly used in the environment. Refer to the
+          tool documentation for more information.
 
-   .. raw:: html
+       .. _install-qiskit-ibmq-provider:
 
-      <h2>Installing IBM Quantum Provider from Source</h2>
+       .. raw:: html
 
-   1. Clone the qiskit-ibmq-provider repository.
+          <h2>Installing IBM Quantum Provider from Source</h2>
 
-      .. code:: sh
+       1. Clone the qiskit-ibmq-provider repository.
 
-         git clone https://github.com/Qiskit/qiskit-ibmq-provider.git
+          .. code:: sh
 
-   2. Cloning the repository creates a local directory called ``qiskit-ibmq-provider``.
+             git clone https://github.com/Qiskit/qiskit-ibmq-provider.git
 
-      .. code:: sh
+       2. Cloning the repository creates a local directory called ``qiskit-ibmq-provider``.
 
-         cd qiskit-ibmq-provider
+          .. code:: sh
 
-   3. If you want to run tests or linting checks, install the developer requirements.
-      This is not required to install or use the qiskit-ibmq-provider package when
-      installing from source.
+             cd qiskit-ibmq-provider
 
-      .. code:: sh
+       3. If you want to run tests or linting checks, install the developer requirements.
+          This is not required to install or use the qiskit-ibmq-provider package when
+          installing from source.
 
-         pip install -r requirements-dev.txt
+          .. code:: sh
 
-   4. Install qiskit-ibmq-provider.
+             pip install -r requirements-dev.txt
 
-      .. code:: sh
+       4. Install qiskit-ibmq-provider.
 
-         pip install .
+          .. code:: sh
 
-   If you want to install it in editable mode, meaning that code changes to the
-   project don't require a reinstall to be applied:
+             pip install .
 
-   .. code:: sh
+       If you want to install it in editable mode, meaning that code changes to the
+       project don't require a reinstall to be applied:
 
-      pip install -e .
+       .. code:: sh
+
+          pip install -e .
 
 Platform Support
 ----------------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1558 the sphinx plugin sphinx-panel was switched to sphinx-design to
enable building the documentation with sphinx >=5.0.0. However, while
the build succeeded there were warnings emitted about tabbed directive
which was only valid for sphinx-panel. This prevented any tabbed
sections in the documentation from being built as sphinx just ignored
it (this is why it's best practice to build with -W to make warnings
fatal because they're almost always pointing to broken docs). This
commit fixes this by migrating the directives to use the syntax from
sphinx-design so that we're building the tabs sections of the
documentation.

### Details and comments

Fixes #1566