### PR TITLE
Separate stable version list from language menu

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -168,7 +168,6 @@
   {% block extrabody %} {% endblock %}
 
     {# SIDE NAV, TOGGLES ON MOBILE #}
-
     {% include "versions.html" %}
 
     <div class="table-of-contents-link-wrapper">
@@ -219,6 +218,7 @@
           {% endblock %}
         </div>
       </div>
+      {% include "stable_versions.html" %}
     </nav>
 
     <div class="pytorch-container">

--- a/docs/_templates/stable_versions.html
+++ b/docs/_templates/stable_versions.html
@@ -1,7 +1,7 @@
 <div>
     <dl>
       <dt>Previous Releases</dt>
-      {% for version in version_list %}
+      {% for version in version_list | sort(reverse=True) %}
         <dd><a class="version" href="/documentation/stable/{{ version }}/index.html">{{ version }}</a></dd>
       {% endfor %}
     </dl>

--- a/docs/_templates/stable_versions.html
+++ b/docs/_templates/stable_versions.html
@@ -1,0 +1,8 @@
+<div>
+    <dl>
+      <dt>Previous Releases</dt>
+      {% for version in version_list %}
+        <dd><a class="version" href="/documentation/stable/{{ version }}/index.html">{{ version }}</a></dd>
+      {% endfor %}
+    </dl>
+</div>

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,6 +1,6 @@
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
-    <span class="rst-current-version-label">{{ version_label }}</span>
+    <span class="rst-current-version-label">{{ language_label }}</span>
     <span class="rst-versions-dropdown-icon"></span>
   </span>
   <div class="rst-other-versions">
@@ -12,12 +12,6 @@
       {% endfor %}
     </dl>
     {% endif %}
-    <dl>
-      <dt>Previous Releases</dt>
-      {% for version in version_list %}
-        <dd><a class="version" href="/documentation/stable/{{ version }}/index.html">{{ version }}</a></dd>
-      {% endfor %}
-    </dl>
   </div>
   <script>
     jQuery('.version').click((evt) => {

--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -56,6 +56,7 @@ def _extend_html_context(app, config):
     context['current_translation'] = _get_current_translation(config) or config.language
     context['translation_url'] = partial(_get_translation_url, config)
     context['version_label'] = _get_version_label(config)
+    context['language_label'] = _get_language_label(config)
 
 
 def _get_current_translation(config):
@@ -74,12 +75,13 @@ def _get_translation_url(config, code, pagename):
 
 def _get_version_label(config):
     proc = subprocess.run(
-        ['git', 'describe', '--exact-match', '--tags', 'HEAD'],
+        ['git', 'describe', '--abbrev=0', '--tags', 'HEAD'],
         encoding='utf8', capture_output=True)
-    if proc.returncode != 0:
-        return '%s' % (_get_current_translation(config) or config.language,)
-    else:
-        return proc.stdout
+    return proc.stdout
+
+def _get_language_label(config):
+    return '%s' % (_get_current_translation(config) or config.language,)
+
 
 
 def _get_version_list():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The language menu is using a widget/theme element rst-versions which in
the original rtd theme (which is the grandparent of the qiskit sphinx
theme) is a pop up/dropdown menu that has a bunch of extra information
in it that can be used to list different versions of the documentation
as well as download links. In #1261 that functionality was used to add a
list of stable versions to the sidebar since it was the logical place
for it. However, this has apparently been a source of confusion for most
users as unless they have prior knowledge about the previous version
links being on the same menu as the language selection and the
availability of old versions of the documentation goes unnoticed. This
commit addresses this by splitting the previous versions list out of the
language selector drop down and just adding a list to the bottom of the
side bar. We can change the formatting and style of this as needed in
the future, but at least for right now it gives us a clear location for
links to old version of the documenation.


### Details and comments
Fixes #1266

