### PR TITLE
putting back the Qiskit Metal card

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,19 +85,22 @@ Interested in running experiments on real qubits?
 Interested in quantum hardware design?
 ######################################
 
-   .. panels::
+   .. grid:: 2
 
-    Qiskit Metal
-    ^^^^^^^^^^^^^^
+    .. grid-item-card::
+        :columns: auto
 
-    .. image:: images/metal.png
-      :scale: 35 %
-      :align: center
-      :target: https://qiskit.org/documentation/metal/
+        Qiskit Metal
+        ^^^^^^^^^^^^^^
 
-    ++++++
-    :link-badge:`https://qiskit.org/metal,"Website",cls=badge-dark text-white`
-    :link-badge:`https://qiskit.org/documentation/metal/,"Documentation",cls=badge-primary text-white`
+        .. image:: images/metal.png
+          :scale: 35 %
+          :align: center
+          :target: https://qiskit.org/documentation/metal/
+
+        ++++++
+        :bdg-link-primary-line:`Website <https://qiskit.org/metal>`
+        :bdg-link-primary-line:`Documentation <https://qiskit.org/documentation/metal/>`
 
 
 .. toctree::


### PR DESCRIPTION
Putting back the Qiskit Metal card. Currently looks like this

<img width="692" alt="Screenshot 2022-08-01 at 00 31 45" src="https://user-images.githubusercontent.com/766693/182047894-6c01b7e1-1d11-4e32-852b-5179f4d17c53.png">
 
With this PR, it looks like this

<img width="725" alt="Screenshot 2022-08-01 at 00 31 53" src="https://user-images.githubusercontent.com/766693/182047901-7227cb1e-2d44-401f-9fe9-fa188612a293.png">

