### PR TITLE
Move stable_versions.html to previous div for better alignment

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -216,8 +216,8 @@
               <div class="local-toc">{{ toc }}</div>
             {% endif %}
           {% endblock %}
+          {% include "stable_versions.html" %}
         </div>
-      {% include "stable_versions.html" %}
       </div>
     </nav>
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -217,8 +217,8 @@
             {% endif %}
           {% endblock %}
         </div>
-      </div>
       {% include "stable_versions.html" %}
+      </div>
     </nav>
 
     <div class="pytorch-container">


### PR DESCRIPTION
currently, the list of "Previous Releases" looks misaligned.
 
<img width="358" alt="Screenshot 2022-08-02 at 13 11 31" src="https://user-images.githubusercontent.com/766693/182361121-cf5e123b-3f92-4444-9979-61c42b471696.png">
 
With this PR, it looks like this:

<img width="356" alt="Screenshot 2022-08-02 at 17 55 20" src="https://user-images.githubusercontent.com/766693/182419601-392b6d15-1d28-4baa-9582-b227d2521e95.png">

