### PR TITLE
Add rustworkx to other docs build list

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -7,6 +7,7 @@
 /finance/**
 /experiments/**
 /retworkx/**
+/rustworkx/**
 /stable/**
 /dynamics/**
 /neko/**


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The retworkx project was recently renamed rustworkx (see
Qiskit/rustworkx#644) however the documentation is still being published
to the retworkx url. The project will soon start uploading builds to
qiskit.org/documentation/rustworkx in order to prepare for that this
commit adds the path to the exlude list so syncs of the main qiskit
documentation do not accidently delete the rustworkx documentation.

### Details and comments


