### PR TITLE
Add qiskit-aer documentation to other builds list

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -11,3 +11,4 @@
 /stable/**
 /dynamics/**
 /neko/**
+/aer/**


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the qiskit aer documentation to the other builds path.
This will let qiskit-aer manage publishing its own documentation to
https://qiskit.org/documentation/aer
Starting in the pending 0.11.0 qiskit-aer release it has moved to its
own python package/namespace qiskit_aer which will complicate the
publishing the documentation under the same build as the qiskit main
docs. So aer is moving to publishing it's own doc page in
https://github.com/Qiskit/qiskit-aer/pull/1589


### Details and comments

Related to #1508 