### PR TITLE
fixes #1581: off by one docs version list (possible fix)

### DIFF
--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -94,7 +94,7 @@ def _get_version_list():
     if current_version_info[0] == '0':
         version_list = [
             '0.%s' % x for x in range(start_version[1],
-                                      int(current_version_info[1]) + 1)]
+                                      int(current_version_info[1]))]
     else:
         #TODO: When 1.0.0 add code to handle 0.x version list
         version_list = []


### PR DESCRIPTION
✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

### Summary

I believe this will fix #1581 

### Details and comments

Docs list is off by one and I believe it's simply in the version list generation

I don't have a way to test it since CPLEX won't install on my Mac M1

I also don't see how to test docs either... unless you publish to the qiskit.org site which I would not want to do (obviously).
