### PR TITLE
Fix deploying new docs to old stable tag

### DIFF
--- a/.github/workflows/docs_tag.yml
+++ b/.github/workflows/docs_tag.yml
@@ -25,5 +25,6 @@ jobs:
         encrypted_rclone_key: ${{ secrets.encrypted_rclone_key }}
         encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
         QISKIT_DOCS_BUILD_TUTORIALS: 'always'
+      shell: bash
       run: |
         tools/deploy_documentation_tag.sh ${GITHUB_REF#refs/tags/}

--- a/.github/workflows/docs_tag.yml
+++ b/.github/workflows/docs_tag.yml
@@ -26,4 +26,4 @@ jobs:
         encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
         QISKIT_DOCS_BUILD_TUTORIALS: 'always'
       run: |
-        tools/deploy_documentation_tag.sh
+        tools/deploy_documentation_tag.sh ${GITHUB_REF#refs/tags/}

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -15,6 +15,10 @@
 # Script for pushing the stable documentation.
 set -e
 
+if [ $# -ne 1 ]; then
+    echo "Usage: $(basename "$0") <tag>" >&2 && exit 1
+fi
+
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
 sudo apt-get install -y ./rclone.deb
 
@@ -22,10 +26,11 @@ RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
 echo "show current dir: "
 pwd
-
-CURRENT_TAG=`git describe --abbrev=0`
+CURRENT_TAG=$1
+echo "Got tag $CURRENT_TAG"
 IFS=. read -ra VERSION <<< "$CURRENT_TAG"
 STABLE_VERSION="${VERSION[0]}.${VERSION[1]}"
+echo "Building for stable version $STABLE_VERSION"
 
 # Build the documentation.
 tox -edocs -- -D content_prefix=documentation/stable/"$STABLE_VERSION" -j auto


### PR DESCRIPTION
### Summary

Previously, we relied on inferring the tag from `git describe`.  This has been somewhat unreliable in the past, seemingly not recognising the newest tag when triggered.  It is possible that the VM's git checkout is initialised before the tag is synced into the main repo, which might have caused this.

Instead, we extract the tag from the environment variable GitHub Actions sets to pass to the deployment script directly.  This is guaranteed to give the correct tag.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->



### Details and comments

Fix #1581.  Close #1597.  Actually, the online documentation won't be fixed until we run through the old stable versions and re-upload them, but this should fix the deployment script writing the first of a new minor version into the wrong place.