### PR TITLE
Fix redirect path for qiskit-aer modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ for tutorial in experiments_tutorials:
 
 with open("aer_sources.txt", "r") as fd:
     for source_str in fd:
-        target_str = source_str.replace("qiskit.providers.aer", "qiskit_aer")
+        target_str = f"../{source_str.replace('qiskit.providers.aer', 'qiskit_aer')}"
         redirects[source_str] = target_str
 
 nbsphinx_timeout = 300


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1596 we added redirects from the old qiskit aer module paths to the new `qiskit_aer` path. However, that PR added the redirects relative to the root of the docs build and the sphinx-reredirects module does the redirects relative to the dir of the source path. This is causing the destination of the redirects to go to the wrong URL resulting in a 404. This commit updates the redirect configuration to ensure that the destination path is correct by treating the destination path relative to the source path which fixes the broken redirects.

### Details and comments