### PR TITLE
Add s390x and ppc64le as tier 3 supported platforms

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -577,11 +577,17 @@ platforms are best effort only.
 
 Tier 3 platforms are currently:
 
+ * Linux ppc64le (distributions compatible with the
+   `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__ packaging
+   specification)
+ * Linux s390x (distributions compatible with the
+   `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__ packaging
+   specification)
+ * macOS arm64 (10.15 or newer)
  * Linux i686 (distributions compatible with the
    `manylinux 2014 <https://www.python.org/dev/peps/pep-0599/>`__ packaging
    specification) for Python >= 3.10
  * Windows 32 bit for Python >= 3.10
- * macOS arm64 (10.15 or newer)
 
 Ready to get going?...
 ======================


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of qiskit-aer 0.11.0 all the qiskit packages with compiled extensions now are publishing precompiled binaries for s390x and ppc64le. This commit updates the supported platform documentation to indicate that we support these platforms at tier 3, meaning we build and publish binaries at release time but do not have CI testing or infrastructure to test the binaries post build.

### Details and comments