### PR TITLE
Bugfix: docs header svg is now clickable

### DIFF
--- a/docs/images/qiskit_main.svg
+++ b/docs/images/qiskit_main.svg
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="1137"
-   height="566.55072"
    viewBox="0 0 1137 566.55072"
    fill="none"
    version="1.1"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-.. figure:: images/qiskit_main.svg
-  :align: center
+.. raw:: html
+   :file: images/qiskit_main.svg
 
 ##############################
 Qiskit |version| documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,13 @@
 .. raw:: html
-   :file: images/qiskit_main.svg
+
+  <div style="width: 100%; align: center">
+
+.. raw:: html
+  :file: images/qiskit_main.svg
+
+.. raw:: html
+
+  </div>
 
 ##############################
 Qiskit |version| documentation


### PR DESCRIPTION
### Summary
The svg for the header image on qiskit.org/documentation has hyperlinks for each title, but they are currently only clickable if a user opens the image separately. This PR updates the `index.rst` file to make the svg links clickable from the webpage (this file now uses the same html object used in `docs/contrubute_to_qiskit` to make the flowchart links clickable)



