### PR TITLE
Restrict importlib_metadata to working version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -8,3 +8,7 @@ docutils==0.16
 # to work with the new jinja version (the jinja maintainers aren't going to
 # fix things) pin to the previous working version.
 jinja2==3.0.3
+
+# importlib_metadata 5.0 is broken with stevedore, so pin to the last
+# functional version in the 4.x series.
+importlib_metadata<5.0


### PR DESCRIPTION
### Summary

`importlib_metadata` 5.0 broke `stevedore`, which we and several of our dependents use.  Until this is fixed upstream or Python 3.7 is dropped, we need to restrict the version of `importlib_metadata`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments


