### PR TITLE
Reduce number of permutations for assembler benchmarks

### DIFF
--- a/test/benchmarks/assembler.py
+++ b/test/benchmarks/assembler.py
@@ -22,9 +22,9 @@ from .utils import random_circuit
 
 
 class AssemblerBenchmarks:
-    params = ([1, 2, 5, 8],
-              [8, 128, 1024, 2048, 4096],
-              [1, 5, 10, 50, 100])
+    params = ([8],
+              [4096],
+              [1, 100])
     param_names = ['n_qubits', 'depth', 'number of circuits']
     timeout = 600
     version = 2
@@ -40,9 +40,9 @@ class AssemblerBenchmarks:
 
 
 class DisassemblerBenchmarks:
-    params = ([1, 2, 5, 8],
-              [8, 128, 1024, 2048, 4096],
-              [1, 5, 10, 50, 100])
+    params = ([8],
+              [4096],
+              [1, 100])
     param_names = ['n_qubits', 'depth', 'number of circuits']
     timeout = 600
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When running the full benchmark suite the assembler benchmarks take a disproportionately large amount of time to run, especially given the relatively low current importance of the assemble() function. This was primarily due to the number of permutations of the benchmark we ran. At the time all those permutations were added to verify the scaling of the function because it was a potential bottleneck, but this is no longer a concern. This commit drops the parameter sweeps down so that we only run 2 combinations for assemble, basically a fixed sized circuit either by itself or as a batch of 100. This should drastically decrease the runtime cost of these benchmarks but still give us some data for the function moving forward.

### Details and comments