### PR TITLE
Add benchmarks for Sabre on large QFT and QV circuits

### DIFF
--- a/test/benchmarks/qft.py
+++ b/test/benchmarks/qft.py
@@ -15,6 +15,7 @@
 # pylint: disable=missing-docstring,invalid-name,no-member
 # pylint: disable=attribute-defined-outside-init
 
+import itertools
 import math
 
 from qiskit import QuantumRegister, QuantumCircuit
@@ -63,7 +64,7 @@ class QftTranspileBench:
                   seed_transpiler=20220125)
 
 
-class LargeQFTMappingBench:
+class LargeQFTMappingTimeBench:
     timeout = 600.0  # seconds
 
     heavy_hex_size = {115: 7, 409: 13, 1081: 21}
@@ -81,10 +82,38 @@ class LargeQFTMappingBench:
         pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)
         pass_.run(self.dag)
 
-    def track_depth_sabre_swap(self, _n_qubits, heuristic):
-        pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)
-        return pass_.run(self.dag).depth()
 
-    def track_size_sabre_swap(self, _n_qubits, heuristic):
-        pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)
-        return pass_.run(self.dag).size()
+class LargeQFTMappingTrackBench:
+    timeout = 600.0  # seconds, needs to account for the _entire_ setup.
+
+    heavy_hex_size = {115: 7, 409: 13, 1081: 21}
+    params = ([115, 409, 1081], ["lookahead", "decay"])
+    param_names = ["n_qubits", "heuristic"]
+
+    # The benchmarks take a significant amount of time to run, and we don't
+    # want to unnecessarily run things twice to get the two pieces of tracking
+    # information we're interested in.  We cheat by using the setup cache to do
+    # all the calculation work only once, and then each tracker just quickly
+    # pulls the result from the cache to return, saving the duplication.
+
+    def setup_cache(self):
+        def setup(n_qubits, heuristic):
+            qr = QuantumRegister(n_qubits, name="q")
+            dag = circuit_to_dag(build_model_circuit(qr))
+            coupling = CouplingMap.from_heavy_hex(
+                self.heavy_hex_size[n_qubits]
+            )
+            pass_ = SabreSwap(coupling, heuristic, seed=2022_10_27, trials=1)
+            return pass_.run(dag)
+
+        state = {}
+        for params in itertools.product(*self.params):
+            dag = setup(*params)
+            state[params] = {"depth": dag.depth(), "size": dag.size()}
+        return state
+
+    def track_depth_sabre_swap(self, state, *params):
+        return state[params]["depth"]
+
+    def track_size_sabre_swap(self, state, *params):
+        return state[params]["size"]

--- a/test/benchmarks/qft.py
+++ b/test/benchmarks/qft.py
@@ -62,6 +62,7 @@ class QftTranspileBench:
                   coupling_map=coupling_map,
                   seed_transpiler=20220125)
 
+
 class LargeQFTMappingBench:
     timeout = 600.0  # seconds
 
@@ -72,10 +73,13 @@ class LargeQFTMappingBench:
     def setup(self, n_qubits, _heuristic):
         qr = QuantumRegister(n_qubits, name="q")
         self.dag = circuit_to_dag(build_model_circuit(qr))
-        self.coupling = CouplingMap.from_heavy_hex(self.heavy_hex_size[n_qubits])
+        self.coupling = CouplingMap.from_heavy_hex(
+            self.heavy_hex_size[n_qubits]
+        )
 
     def time_sabre_swap(self, _n_qubits, heuristic):
-        SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1).run(self.dag)
+        pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)
+        pass_.run(self.dag)
 
     def track_depth_sabre_swap(self, _n_qubits, heuristic):
         pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)

--- a/test/benchmarks/quantum_volume.py
+++ b/test/benchmarks/quantum_volume.py
@@ -73,7 +73,9 @@ class LargeQuantumVolumeMappingBenchmark:
         if (n_qubits, depth) not in self.allowed_sizes:
             raise NotImplementedError
         seed = 2022_10_27
-        self.dag = circuit_to_dag(build_qv_model_circuit(n_qubits, depth, seed))
+        self.dag = circuit_to_dag(
+            build_qv_model_circuit(n_qubits, depth, seed)
+        )
         self.coupling = CouplingMap.from_heavy_hex(
             self.heavy_hex_distance[n_qubits]
         )

--- a/test/benchmarks/quantum_volume.py
+++ b/test/benchmarks/quantum_volume.py
@@ -74,10 +74,13 @@ class LargeQuantumVolumeMappingBenchmark:
             raise NotImplementedError
         seed = 2022_10_27
         self.dag = circuit_to_dag(build_qv_model_circuit(n_qubits, depth, seed))
-        self.coupling = CouplingMap.from_heavy_hex(self.heavy_hex_distance[n_qubits])
+        self.coupling = CouplingMap.from_heavy_hex(
+            self.heavy_hex_distance[n_qubits]
+        )
 
     def time_sabre_swap(self, _n_qubits, _depth, heuristic):
-        SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1).run(self.dag)
+        pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)
+        pass_.run(self.dag)
 
     def track_depth_sabre_swap(self, _n_qubits, _depth, heuristic):
         pass_ = SabreSwap(self.coupling, heuristic, seed=2022_10_27, trials=1)


### PR DESCRIPTION
### Summary

Sabre is capable of handling these large benchmarks now, and it's of interest for us to track our performance on large systems.  We don't anticipate running on them yet, but we will want to know in the future when further changes to routing and memory usage improve these benchmarks.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

These could be in either `mapping_passes.py` or the files I've put them in.  It's not super clear where, but since I used the benchmark-internal constructors (to dodge issues with the Terra functions potentially changing in the future), it made some sense to put them in the structure-specific files.
