### PR TITLE
Fix analytics environment in deployment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 
 [testenv:docs]
 envdir = .tox/docs
-passenv = DOCS_FROM_MASTER QISKIT_DOCS_BUILD_TUTORIALS
+passenv = DOCS_FROM_MASTER QISKIT_DOCS_BUILD_TUTORIALS QISKIT_ENABLE_ANALYTICS
 extras =
   all
 deps =


### PR DESCRIPTION
### Summary

We were setting the `QISKIT_ENABLE_ANALYTICS` environment variable in the relevant workflow files, but building the documentation with `tox`. `tox` isolates its commands from the environment, except for variables that are explicitly passed through.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

cc: @javabster 
