### PR TITLE
Pin tox version used in CI to <4.0.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/docs_tag.yml
+++ b/.github/workflows/docs_tag.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel pip
+        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel pip
       - name: Install and Run Tests
         run: tox -e py
   lint:
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Run lint
         run: tox -elint
   docs:
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get install -y pandoc graphviz
       - name: Install python Deps
         run: |
-          python -m pip install -U tox
+          python -m pip install -U 'tox<4'
           python -m pip install -r requirements-dev.txt
       - name: Build Docs
         run: tox -edocs -- -j auto
@@ -75,7 +75,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install python Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Setup tutorials
         run: |
           set -e


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The most recent tox release, 4.0.0, is a major rewrite of the internals of tox and several things behave quite differently. [1] This new release is causing CI jobs to fail as something in incompatible with our tox configuration (likely because it's using wheel builds instead of sdists). This commit pins the tox version we're using in CI to unblock things until we can update the tox configuration to be compatible with both the new and old versions of tox.

### Details and comments