### PR TITLE
Add migration guides from terra

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -292,7 +292,7 @@ def _install_from_master():
         subprocess.run(cmd)
 
 
-def _git_copy(package, sha1, api_docs_dir):
+def _git_copy(package, sha1, meta_docs_dir, sub_docs_folder):
     try:
         with tempfile.TemporaryDirectory() as temp_dir:
             github_source = 'https://github.com/Qiskit/%s' % package
@@ -301,8 +301,8 @@ def _git_copy(package, sha1, api_docs_dir):
             subprocess.run(['git', 'checkout', sha1], cwd=temp_dir,
                            capture_output=True)
             dir_util.copy_tree(
-                os.path.join(temp_dir, 'docs', 'apidocs'),
-                api_docs_dir)
+                os.path.join(temp_dir, 'docs', sub_docs_folder),
+                meta_docs_dir)
 
     except FileNotFoundError:
         warnings.warn('Copy from git failed for %s at %s, skipping...' %
@@ -311,22 +311,30 @@ def _git_copy(package, sha1, api_docs_dir):
 
 def load_api_sources(app):
     api_docs_dir = os.path.join(app.srcdir, 'apidoc')
+    migration_guides_dir = os.path.join(app.srcdir, 'migration_guides')
+
     if os.getenv('DOCS_FROM_MASTER'):
         global apidocs_master
         apidocs_master = tempfile.mkdtemp()
         shutil.move(api_docs_dir, apidocs_master)
         _install_from_master()
         for package in qiskit_elements:
-            _git_copy(package, 'HEAD', api_docs_dir)
+            _git_copy(package, 'HEAD', api_docs_dir, 'apidocs')
+        # pull migration guides from qiskit-terra
+        _git_copy('qiskit-terra', 'HEAD', migration_guides_dir, 'migration_guides')
         return
     elif os.path.isdir(api_docs_dir):
         global apidocs_exists
         apidocs_exists = True
         warnings.warn('docs/apidocs already exists skipping source clone')
         return
+
     meta_versions = _get_current_versions(app)
     for package in qiskit_elements:
-        _git_copy(package, meta_versions[package], api_docs_dir)
+        _git_copy(package, meta_versions[package], api_docs_dir, 'apidocs')
+    
+    # pull migration guides from qiskit-terra
+    _git_copy('qiskit-terra', meta_versions['qiskit-terra'], migration_guides_dir, 'migration_guides')
 
 def load_tutorials(app):
     tutorials_dir = os.path.join(app.srcdir, 'tutorials')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -292,7 +292,7 @@ def _install_from_master():
         subprocess.run(cmd)
 
 
-def _git_copy(package, sha1, meta_docs_dir, sub_docs_folder):
+def _git_copy(package, sha1, meta_package_docs_dir, sub_package_docs_folder):
     try:
         with tempfile.TemporaryDirectory() as temp_dir:
             github_source = 'https://github.com/Qiskit/%s' % package
@@ -301,8 +301,8 @@ def _git_copy(package, sha1, meta_docs_dir, sub_docs_folder):
             subprocess.run(['git', 'checkout', sha1], cwd=temp_dir,
                            capture_output=True)
             dir_util.copy_tree(
-                os.path.join(temp_dir, 'docs', sub_docs_folder),
-                meta_docs_dir)
+                os.path.join(temp_dir, 'docs', sub_package_docs_folder),
+                meta_package_docs_dir)
 
     except FileNotFoundError:
         warnings.warn('Copy from git failed for %s at %s, skipping...' %

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,6 +122,7 @@ Interested in quantum hardware design?
    tutorials
    API Reference <apidoc/terra>
    Circuit Library <apidoc/circuit_library>
+   Migration Guides <migration_guides/index>
    release_notes
    configuration
    GitHub <https://github.com/Qiskit/qiskit-terra>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit algorithms team are making migrations guides for qiskit-terra. 
- https://github.com/Qiskit/qiskit-terra/pull/9549
- https://github.com/Qiskit/qiskit-terra/pull/9554
- https://github.com/Qiskit/qiskit-terra/pull/9557

This PR adds the logic to pull `migration_guide` folder from qiskit-terra repo and add `Migration Guides` entry to the sidebar.

On hold until (at least one of) the migration guides are merged and made into a Terra release.

### Details and comments


