### PR TITLE
extension to add a prologue with a deprecation warning in ibmq pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -360,6 +360,14 @@ def clean_tutorials(app, exc):
     tutorials_dir = os.path.join(app.srcdir, 'tutorials')
     shutil.rmtree(tutorials_dir)
 
+def deprecate_ibmq_provider(app, docname, source):
+    message = """.. warning::
+       The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be
+       archived soon. Please transition to the new packages. More information in
+       https://ibm.biz/provider_migration_guide\n\n"""
+    if 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
+        source[0] = message + source[0]
+
 # -- Extension configuration -------------------------------------------------
 
 def setup(app):
@@ -374,3 +382,4 @@ def setup(app):
     app.add_css_file('css/theme-override.css')
     app.connect('build-finished', clean_api_source)
     app.connect('build-finished', clean_tutorials)
+    app.connect('source-read', deprecate_ibmq_provider)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -365,7 +365,7 @@ def deprecate_ibmq_provider(app, docname, source):
        The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be
        archived soon. Please transition to the new packages. More information in
        https://ibm.biz/provider_migration_guide\n\n"""
-    if 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
+    if source[0] and 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
         source[0] = message + source[0]
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -365,7 +365,7 @@ def deprecate_ibmq_provider(app, docname, source):
        The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be
        archived soon. Please transition to the new packages. More information in
        https://ibm.biz/provider_migration_guide\n\n"""
-    if source[0] and 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
+    if source[0].strip() > 1 and 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
         source[0] = message + source[0]
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -365,7 +365,7 @@ def deprecate_ibmq_provider(app, docname, source):
        The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be
        archived soon. Please transition to the new packages. More information in
        https://ibm.biz/provider_migration_guide\n\n"""
-    if len(source[0].strip()) > 1 and 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
+    if 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
         source[0] = message + source[0]
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -365,7 +365,7 @@ def deprecate_ibmq_provider(app, docname, source):
        The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be
        archived soon. Please transition to the new packages. More information in
        https://ibm.biz/provider_migration_guide\n\n"""
-    if source[0].strip() > 1 and 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
+    if len(source[0].strip()) > 1 and 'apidoc/ibmq' in docname or 'qiskit.providers.ibmq' in docname:
         source[0] = message + source[0]
 
 # -- Extension configuration -------------------------------------------------


### PR DESCRIPTION
This PR is the real https://github.com/Qiskit/qiskit-ibmq-provider/pull/1156. Prefixes all the pages related with `qiskit-ibmq-provider` with a warning message to a link to the migration guides.

<img width="937" src="https://user-images.githubusercontent.com/766693/219664307-cbe9de28-9986-40ae-8ae2-2174b94d404f.png">

Thanks @mtreinish for the help!