### PR TITLE
Explicitly set that this is a meta package only

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,6 @@
 astroid==2.3.3
 pylint==2.4.4
-cryptography==2.5.0
+cryptography==39.0.1
 decorator==4.4.2
 docutils==0.16
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ setup(
     author="Qiskit Development Team",
     author_email="hello@qiskit.org",
     license="Apache 2.0",
+    py_modules=[],
+    packages=[],
     classifiers=[
         "Environment :: Console",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit is a meta-package, meaning that we do not bundle any code from this repo in the `qiskit` PyPI package. We only include dependencies on other repos.

We were not explicitly setting this, so `setup.py` run via Tox's pip was trying to auto-discover what the code's package was, resulting in an error. Instead, we should be explicit.

### Details and comments

Both @HuangJunye and I get this error locally via `tox -e py`:

```
 × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['stubs', 'images'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.
      [end of output]

```

No idea how CI has been passing.

Also updates `cryptography` to a version that works on Apple Silicon. With this PR, `tox -e py` works on my M1.
