### PR TITLE
[WAIT TO MERGE] Add extension to add deprecated directives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,3 +273,4 @@ def setup(app):
     app.connect('build-finished', custom_extensions.clean_api_source)
     app.connect('build-finished', custom_extensions.clean_tutorials)
     app.connect('source-read', custom_extensions.deprecate_ibmq_provider)
+    app.connect('autodoc-process-docstring', custom_extensions.add_qiskit_deprecation)

--- a/docs/custom_extensions.py
+++ b/docs/custom_extensions.py
@@ -159,30 +159,26 @@ def add_qiskit_deprecation(app, what, name, obj, options, lines) -> None:
     if not new_lines:
         return
 
+    # Defensively add new lines to the beginning and end. This is sometimes necessary, depending
+    # on the original docstring. It does not hurt to have extra.
+    new_lines.insert(0, "")
+    new_lines.append("")
+
     # From https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists.
     # Since we only check that the line starts with these, we don't need the longer aliases that
     # are covered by their shorter aliases.
     meta_prefixes = {":param", ":arg", ":key", ":type", ":return", ":rtype", ":raise", ":except"}
     meta_index = next(
         (
-            i for i, line
+            i
+            for i, line
             in enumerate(lines)
             if any(line.startswith(prefix) for prefix in meta_prefixes)
         ),
         None,
     )
-    if meta_index and not (meta_index >= 1 and lines[meta_index - 1] == ""):
-        raise AssertionError(
-            "Expected there to be a blank line before metadata lines like `:param`. "
-            "This means the deprecation extension is probably broken. Please open a bug at"
-            "https://github.com/Qiskit/qiskit and include this:\n\n"
-            f"{name}\n\n{lines}"
-        )
 
     if meta_index:
-        # When parameter metadata is provided, we need to insert a blank link.
-        if meta_index >= 2 and lines[meta_index - 2] != "":
-            new_lines.insert(0, "")
         lines[meta_index - 1 : meta_index - 1] = new_lines
     else:
         lines.extend(new_lines)

--- a/docs/custom_extensions.py
+++ b/docs/custom_extensions.py
@@ -146,26 +146,25 @@ def add_qiskit_deprecation(app, what, name, obj, options, lines) -> None:
     Implementation note: this extension happens after the function has already been normalized via
     Napoleon, i.e. converted from Google's docstring style to standard RST.
     """
-    if what not in {"function", "method"} or not hasattr(obj, "__qiskit_deprecation__"):
+    if what not in {"function", "method"} or not hasattr(obj, "__qiskit_deprecations__"):
         return
-    metadata = getattr(obj, "__qiskit_deprecation__")
 
-    def generate_directive(entry) -> list[str]:
+    new_lines = []
+    for entry in getattr(obj, "__qiskit_deprecations__"):
         version_str = f"{entry.since}_pending" if entry.pending else entry.since
-        spaces = "  "
-        return [f".. deprecated:: {version_str}", f"{spaces}{entry.msg}"]
+        new_lines.extend([f".. deprecated:: {version_str}", f"  {entry.msg}"])
+    if not new_lines:
+        return
 
     # From https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists.
     # Since we only check that the line starts with these, we don't need the longer aliases that
     # are covered by their shorter aliases.
-    arg_prefixes = {":param", ":arg", ":key", ":type"}
-    additional_prefixes = {":return", ":rtype", ":raise", ":except"}
-
+    meta_prefixes = {":param", ":arg", ":key", ":type", ":return", ":rtype", ":raise", ":except"}
     meta_index = next(
         (
             i for i, line
             in enumerate(lines)
-            if any(line.startswith(prefix) for prefix in {*arg_prefixes, *additional_prefixes})
+            if any(line.startswith(prefix) for prefix in meta_prefixes)
         ),
         None,
     )
@@ -177,11 +176,9 @@ def add_qiskit_deprecation(app, what, name, obj, options, lines) -> None:
             f"{name}\n\n{lines}"
         )
 
-    if metadata.func_deprecation is not None:
-        directive = generate_directive(metadata.func_deprecation)
-        if meta_index:
-            if meta_index >= 2 and lines[meta_index - 2] != "":
-                directive.insert(0, "")
-            lines[meta_index - 1 : meta_index - 1] = directive
-        else:
-            lines.extend(directive)
+    if meta_index:
+        if meta_index >= 2 and lines[meta_index - 2] != "":
+            new_lines.insert(0, "")
+        lines[meta_index - 1 : meta_index - 1] = new_lines
+    else:
+        lines.extend(new_lines)

--- a/docs/custom_extensions.py
+++ b/docs/custom_extensions.py
@@ -177,6 +177,7 @@ def add_qiskit_deprecation(app, what, name, obj, options, lines) -> None:
         )
 
     if meta_index:
+        # When parameter metadata is provided, we need to insert a blank link.
         if meta_index >= 2 and lines[meta_index - 2] != "":
             new_lines.insert(0, "")
         lines[meta_index - 1 : meta_index - 1] = new_lines

--- a/docs/custom_extensions.py
+++ b/docs/custom_extensions.py
@@ -151,7 +151,10 @@ def add_qiskit_deprecation(app, what, name, obj, options, lines) -> None:
 
     new_lines = []
     for entry in getattr(obj, "__qiskit_deprecations__"):
-        version_str = f"{entry.since}_pending" if entry.pending else entry.since
+        if entry.since is None:
+            version_str = "unknown"
+        else:
+            version_str = f"{entry.since}_pending" if entry.pending else entry.since
         new_lines.extend([f".. deprecated:: {version_str}", f"  {entry.msg}"])
     if not new_lines:
         return

--- a/docs/custom_extensions_test.py
+++ b/docs/custom_extensions_test.py
@@ -24,7 +24,7 @@ class DeprecationMetadataEntry:
     """Emulates the type from Terra's deprecation.py."""
 
     msg: str
-    since: str
+    since: Optional[str]
     pending: bool
 
 
@@ -237,4 +237,11 @@ class CustomExtensionsTest(TestCase):
             deprecations=[pending_entry],
             original=[],
             expected=[".. deprecated:: 9.999_pending", "  Deprecated!"]
+        )
+        # The version might not have been set.
+        unknown_version_entry = dataclasses.replace(entry, since=None)
+        assert_deprecation(
+            deprecations=[unknown_version_entry],
+            original=[],
+            expected=[".. deprecated:: unknown", "  Deprecated!"]
         )

--- a/docs/custom_extensions_test.py
+++ b/docs/custom_extensions_test.py
@@ -1,0 +1,231 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from unittest import TestCase
+from unittest.mock import Mock
+
+from docs.custom_extensions import add_qiskit_deprecation
+
+
+@dataclass(frozen=True)
+class DeprecationMetadataEntry:
+    """Emulates the type from Terra's deprecation.py."""
+
+    msg: str
+    since: str
+    pending: bool
+
+
+@dataclass(frozen=True)
+class DeprecationMetadata:
+    """Emulates the type from Terra's deprecation.py."""
+
+    func_deprecation: Optional[DeprecationMetadataEntry]
+    args_deprecations: Dict[str, DeprecationMetadataEntry]
+
+
+class CustomExtensionsTest(TestCase):
+    def test_add_qiskit_deprecation(self) -> None:
+        """Test that we correctly insert the deprecation directive at the right location.
+
+        These test cases were manually created by adding this simplified version of the extension in
+        the `qiskit-ibmq-provider` repo to its `conf.py` (any Qiskit repo will do):
+
+            def add_qiskit_deprecation(app, what, name, obj, options, lines):
+                if not hasattr(obj, "__qiskit_deprecation__"):
+                    return
+                directive = [".. deprecated:: 1.2", "  HERE"]
+                print("BEFORE")
+                print(lines)
+                # INSTRUCTIONS: change this line to insert where you want the directive.
+                lines.extend(directive)
+                print("AFTER")
+                print(lines)
+
+            def setup(app):
+                app.connect('autodoc-process-docstring', add_qiskit_deprecation)
+
+        Then, add `__qiskit_deprecation = True` to some function, and generate the docs. Ensure that
+        no Sphinx warnings were created, and visually review the generated docs to make sure the
+        directive is rendered properly. If valid, then use the `BEFORE` and `AFTER` to determine
+        the `original` and `expected` arguments for this test. Change the docstring and/or type
+        hints to generate new edge cases.
+        """
+        def assert_deprecation(
+            *,
+            metadata: Optional[DeprecationMetadata],
+            original: List[str],
+            expected: List[str],
+        ) -> None:
+            func = Mock()
+            if metadata:
+                func.__qiskit_deprecation__ = metadata
+
+            add_qiskit_deprecation(
+                app=Mock(),
+                what="function",
+                name="my_func",
+                obj=func,
+                options=Mock(),
+                lines=original,
+            )
+            self.assertEqual(original, expected)
+
+        assert_deprecation(metadata=None, original=["line 1"], expected=["line 1"])
+        assert_deprecation(
+            metadata=DeprecationMetadata(func_deprecation=None, args_deprecations={}),
+            original=["line 1"],
+            expected=["line 1"],
+        )
+
+        # Test deprecations of the function.
+        entry = DeprecationMetadataEntry("Deprecated!", since="9.999", pending=False)
+        metadata = DeprecationMetadata(func_deprecation=entry, args_deprecations={})
+        assert_deprecation(
+            metadata=metadata,
+            original=[],
+            expected=[".. deprecated:: 9.999", "  Deprecated!"],
+        )
+        assert_deprecation(
+            metadata=metadata,
+            original=[
+                "No args/return sections.",
+                "",
+            ],
+            expected=[
+                "No args/return sections.",
+                "",
+                ".. deprecated:: 9.999",
+                "  Deprecated!",
+            ],
+        )
+        assert_deprecation(
+            metadata=metadata,
+            original=[
+                "Paragraph 1, line 1.",
+                "Line 2.",
+                "",
+                "Paragraph 2.",
+                "",
+                "",
+            ],
+            expected=[
+                "Paragraph 1, line 1.",
+                "Line 2.",
+                "",
+                "Paragraph 2.",
+                "",
+                "",
+                ".. deprecated:: 9.999",
+                "  Deprecated!",
+            ],
+        )
+        assert_deprecation(
+            metadata=metadata,
+            original=[
+                "A list.",
+                "  * element 1",
+                "  * element 2",
+                "    continued",
+                "",
+            ],
+            expected=[
+                "A list.",
+                "  * element 1",
+                "  * element 2",
+                "    continued",
+                "",
+                ".. deprecated:: 9.999",
+                "  Deprecated!",
+            ],
+        )
+        # Check that we correctly insert the directive in-between the function description
+        # and metadata args. See
+        # https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists.
+        for metadata_line in [
+            ":param foo:",
+            ":parameter foo:",
+            ":arg foo:",
+            ":argument foo:",
+            ":key foo:",
+            ":keyword foo:",
+            ":type foo:",
+            ":raise ValueError:",
+            ":raises ValueError:",
+            ":except ValueError:",
+            ":exception ValueError:",
+            ":return: blah",
+            ":returns: blah",
+            ":rtype: blah",
+        ]:
+            assert_deprecation(
+                metadata=metadata,
+                original=["", metadata_line],
+                expected=[".. deprecated:: 9.999", "  Deprecated!", "", metadata_line],
+            )
+            assert_deprecation(
+                metadata=metadata,
+                # For some metadata configurations, like only having the return type, we can expect
+                # two blank lines between the docstring and metadata.
+                original=[
+                    "Docstring.",
+                    "",
+                    "",
+                    metadata_line,
+                ],
+                expected=[
+                    "Docstring.",
+                    "",
+                    ".. deprecated:: 9.999",
+                    "  Deprecated!",
+                    "",
+                    metadata_line,
+                ],
+            )
+            assert_deprecation(
+                metadata=metadata,
+                # For some metadata configurations, like only having the param type, there will
+                # only be one blank line between the docstring and metadata.
+                original=[
+                    "Docstring.",
+                    "",
+                    metadata_line,
+                    "",
+                ],
+                expected=[
+                    "Docstring.",
+                    "",
+                    ".. deprecated:: 9.999",
+                    "  Deprecated!",
+                    "",
+                    metadata_line,
+                    "",
+                ],
+            )
+
+        # Test deprecated arguments.
+        metadata = DeprecationMetadata(func_deprecation=None, args_deprecations={"my_arg": entry})
+
+        # Test both a deprecated function and arguments.
+        pass
+
+        # Pending should add `_pending` to the version string.
+        pending_entry = dataclasses.replace(entry, pending=True)
+        assert_deprecation(
+            # TODO: add args
+            metadata=DeprecationMetadata(func_deprecation=pending_entry, args_deprecations={}),
+            original=[],
+            expected=[".. deprecated:: 9.999_pending", "  Deprecated!"]
+        )

--- a/docs/custom_extensions_test.py
+++ b/docs/custom_extensions_test.py
@@ -36,7 +36,7 @@ class DeprecationExtensionTest(TestCase):
         def add_qiskit_deprecation(app, what, name, obj, options, lines):
             if not hasattr(obj, "__qiskit_deprecation__"):
                 return
-            directive = [".. deprecated:: 1.2", "  HERE"]
+            directive = ["", ".. deprecated:: 1.2", "  HERE", ""]
             print("BEFORE")
             print(lines)
             # INSTRUCTIONS: change this line to insert where you want the directive.
@@ -88,7 +88,7 @@ class DeprecationExtensionTest(TestCase):
         self.assert_deprecation(
             deprecations=[entry],
             original=[],
-            expected=[".. deprecated:: 9.999", "  Deprecated!"],
+            expected=["", ".. deprecated:: 9.999", "  Deprecated!", ""],
         )
         self.assert_deprecation(
             deprecations=[entry],
@@ -99,8 +99,10 @@ class DeprecationExtensionTest(TestCase):
             expected=[
                 "No args/return sections.",
                 "",
+                "",
                 ".. deprecated:: 9.999",
                 "  Deprecated!",
+                "",
             ],
         )
         self.assert_deprecation(
@@ -120,8 +122,10 @@ class DeprecationExtensionTest(TestCase):
                 "Paragraph 2.",
                 "",
                 "",
+                "",
                 ".. deprecated:: 9.999",
                 "  Deprecated!",
+                "",
             ],
         )
         self.assert_deprecation(
@@ -139,20 +143,24 @@ class DeprecationExtensionTest(TestCase):
                 "  * element 2",
                 "    continued",
                 "",
+                "",
                 ".. deprecated:: 9.999",
                 "  Deprecated!",
+                "",
             ],
         )
         self.assert_deprecation(
             deprecations=[entry, entry, entry],
             original=[],
             expected=[
+                "",
                 ".. deprecated:: 9.999",
                 "  Deprecated!",
                 ".. deprecated:: 9.999",
                 "  Deprecated!",
                 ".. deprecated:: 9.999",
                 "  Deprecated!",
+                "",
             ],
         )
 
@@ -177,8 +185,18 @@ class DeprecationExtensionTest(TestCase):
         ]:
             self.assert_deprecation(
                 deprecations=[entry],
-                original=["", metadata_line],
-                expected=[".. deprecated:: 9.999", "  Deprecated!", "", metadata_line],
+                original=[
+                    "",
+                    metadata_line,
+                ],
+                expected=[
+                    "",
+                    ".. deprecated:: 9.999",
+                    "  Deprecated!",
+                    "",
+                    "",
+                    metadata_line,
+                ],
             )
             self.assert_deprecation(
                 deprecations=[entry],
@@ -193,8 +211,10 @@ class DeprecationExtensionTest(TestCase):
                 expected=[
                     "Docstring.",
                     "",
+                    "",
                     ".. deprecated:: 9.999",
                     "  Deprecated!",
+                    "",
                     "",
                     metadata_line,
                 ],
@@ -215,6 +235,7 @@ class DeprecationExtensionTest(TestCase):
                     ".. deprecated:: 9.999",
                     "  Deprecated!",
                     "",
+                    "",
                     metadata_line,
                     "",
                 ],
@@ -223,10 +244,12 @@ class DeprecationExtensionTest(TestCase):
                 deprecations=[entry, entry],
                 original=["", metadata_line],
                 expected=[
+                    "",
                     ".. deprecated:: 9.999",
                     "  Deprecated!",
                     ".. deprecated:: 9.999",
                     "  Deprecated!",
+                    "",
                     "",
                     metadata_line,
                 ],
@@ -237,7 +260,7 @@ class DeprecationExtensionTest(TestCase):
         self.assert_deprecation(
             deprecations=[entry],
             original=[],
-            expected=[".. deprecated:: 9.999_pending", "  Deprecated!"]
+            expected=["", ".. deprecated:: 9.999_pending", "  Deprecated!", ""]
         )
 
     def test_deprecations_since_not_set(self) -> None:
@@ -246,5 +269,5 @@ class DeprecationExtensionTest(TestCase):
         self.assert_deprecation(
             deprecations=[entry],
             original=[],
-            expected=[".. deprecated:: unknown", "  Deprecated!"]
+            expected=["", ".. deprecated:: unknown", "  Deprecated!", ""]
         )

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ setenv =
   LC_ALL=en_US.utf-8
 commands =
   pip check
-  python -m unittest -v
+  python -m unittest -v  # Runs on the `test` folder.
+  python -m unittest -v docs/custom_extensions_test.py
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Rework of https://github.com/Qiskit/qiskit-terra/pull/8600.

Qiskit repos can add the attribute `__qiskit_deprecations__` to any function object, which is done automatically by the `@deprecated` decorators (https://github.com/Qiskit/qiskit-terra/pull/9611 adds this for Terra). Then, this PR's extension knows to look for that attribute and converts it into Sphinx's deprecated directives. 

This design frees up docstring authors from needing to directly insert deprecated directives in their docstring, which is finicky to format correctly and would require duplicating information from the runtime warnings they already have.

### Details and comments

This renders all deprecations in-between the function's docstring and any metadata, like arguments and the return type. There can be >1 deprecation - each will be its own warning box. 

For example (although this doesn't have the Sphinx Theme formatting):

<img width="834" alt="Screenshot 2023-02-23 at 2 24 28 PM" src="https://user-images.githubusercontent.com/14852634/221021895-49c2fc0f-7c01-4998-8573-8dfda8f699ad.png">

Sometimes, we deprecate arguments rather than the function itself. Originally, I was trying to get deprecations for arguments to show up in the "Parameters" section for its entry, like this:

<img width="844" alt="Screenshot 2023-02-23 at 2 35 25 PM" src="https://user-images.githubusercontent.com/14852634/221024109-5bae4b01-37a0-4229-8253-c546cd8cc033.png">

But, this requires a bad hack: to get the deprecation directive to render, we must remove any docstring written for that parameter. For example, this docstring gives important context for anyone who has not yet migrated:

<img width="793" alt="Screenshot 2023-02-23 at 2 32 03 PM" src="https://user-images.githubusercontent.com/14852634/221023351-d28d0d61-3917-4cfa-ae89-434565e726c2.png">

(Trying to get the deprecation to show up next to the parameter also resulted in complex and confusing code.)

So instead, the deprecation is rendered in-between the function docstring and the parameter list:

<img width="810" alt="Screenshot 2023-02-23 at 2 37 13 PM" src="https://user-images.githubusercontent.com/14852634/221024429-35b2621b-74a6-4f77-9b4c-fbaca108388a.png">
