### PR TITLE
Minor import statement update 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath('.'))
 
-from docs import custom_extensions
+import custom_extensions
 from custom_directives import (IncludeDirective, GalleryItemDirective,
                                CustomGalleryItemDirective, CustomCalloutItemDirective,
                                CustomCardItemDirective)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The [translation build](https://github.com/qiskit-community/qiskit-translations/actions/runs/4308564898/jobs/7514982619#step:5:164) in qiskit-translations repo errors with the error

```bash
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/sphinx/config.py", line 350, in eval_config_file
    exec(code, namespace)
  File "/home/runner/work/qiskit-translations/qiskit-translations/docs/conf.py", line 27, in <module>
    from docs import custom_extensions
ModuleNotFoundError: No module named 'docs'
```

Though the reason for why it fails is a bit unclear, changing `from docs import custom_extensions` to `import custom_extensions` might fix the issue and can maintain a consistency.

### Details and comments


