### PR TITLE
Remove dependency on sphinx-autodoc-typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,6 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
-    'sphinx_autodoc_typehints',
     'jupyter_sphinx',
     'nbsphinx',
     'sphinx_design',
@@ -160,6 +159,13 @@ html_context = {'analytics_enabled': os.getenv('QISKIT_ENABLE_ANALYTICS', False)
 autosummary_generate = True
 autosummary_generate_overwrite = False
 autoclass_content = 'both'
+
+# Move type hints from signatures to the parameter descriptions (except in overload cases, where
+# that's not possible).
+autodoc_typehints = "description"
+# Only add type hints from signature to description body if the parameter has documentation.  The
+# return type is always added to the description (if in the signature).
+autodoc_typehints_description_target = "documented_params"
 
 # Plot directive configuration
 # ----------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 qiskit-ibmq-provider[visualization]
 numpy>=1.17
-Sphinx~=4.0
+Sphinx>=5.0
 qiskit-sphinx-theme~=1.10.3
-sphinx-autodoc-typehints>=1.8.0
 pylatexenc>=1.4
 sphinx-automodapi
 jupyter


### PR DESCRIPTION
### Summary

Since Sphinx 5, this has had first-party support.  This removes a docs dependency that has caused us significant problems before due to its instability, and the built-in handling in `autodoc` is much cleaner as well.  This commit is a mirror of Terra commit dfcfa4a.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

Mirror of Qiskit/qiskit-terra#9705.
