### PR TITLE
Upgrade Sphinx theme to 1.11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 qiskit-ibmq-provider[visualization]
 numpy>=1.17
 Sphinx>=5.0
-qiskit-sphinx-theme~=1.10.3
+qiskit-sphinx-theme~=1.11.0
 pylatexenc>=1.4
 sphinx-automodapi
 jupyter


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

See https://github.com/Qiskit/qiskit_sphinx_theme/releases/tag/1.11.0 for the detailed changelog.

Some highlights:

* Fixed IBM fonts not loading
* Left sidebar can have expandable sections
* Left sidebar shows the previous versions as an expandable section now, unexpanded by default
* Page table of contents on the right stays fixed when scrolling

![screenshot_2023-04-10_at_10 56 13_am_720](https://user-images.githubusercontent.com/14852634/232599035-7b20007d-b13c-4f9f-8761-18a9ae79baf8.png)