### PR TITLE
Fix opflow migration link in release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -58,7 +58,7 @@ the :mod:`qiskit.algorithms` module to be based on the computational
 existing users to migrate to the new workflow:
 
   * ``QuantumInstance`` migration guide: https://qisk.it/qi_migration
-  * ``Opflow`` migration guide: https://qisk.it/qi_migration
+  * ``Opflow`` migration guide: https://qisk.it/opflow_migration
   * Algorithms migration guide: https://qisk.it/algo_migration
 
 OpenQASM2 improvements


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Corrects the short link for the opflow migration in release notes


### Details and comments


