### PR TITLE
Restore mistakenly deleted customcardelement directive

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 import custom_extensions
 import url_redirects
-from custom_directives import CustomCalloutItemDirective
+from custom_directives import CustomCalloutItemDirective, CustomCardItemDirective
 
 # -- General configuration ---------------------------------------------------
 
@@ -175,6 +175,7 @@ plot_html_show_formats = False
 
 def setup(app):
     app.add_directive("customcalloutitem", CustomCalloutItemDirective)
+    app.add_directive("customcarditem", CustomCardItemDirective)
     custom_extensions.load_api_sources(app)
     custom_extensions.load_tutorials(app)
     app.setup_extension("versionutils")

--- a/docs/custom_directives.py
+++ b/docs/custom_directives.py
@@ -15,6 +15,86 @@ from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
 
 
+class CustomCardItemDirective(Directive):
+    option_spec = {
+        "header": directives.unchanged,
+        "image": directives.unchanged,
+        "link": directives.unchanged,
+        "card_description": directives.unchanged,
+        "tags": directives.unchanged,
+    }
+
+    def run(self):
+        try:
+            if "header" in self.options:
+                header = self.options["header"]
+            else:
+                raise ValueError("header not doc found")
+
+            if "image" in self.options:
+                image = "<img src='" + self.options["image"] + "'>"
+            else:
+                image = "_static/img/thumbnails/default.png"
+
+            if "link" in self.options:
+                link = self.options["link"]
+            else:
+                link = ""
+
+            if "card_description" in self.options:
+                card_description = self.options["card_description"]
+            else:
+                card_description = ""
+
+            if "tags" in self.options:
+                tags = self.options["tags"]
+            else:
+                tags = ""
+
+        except FileNotFoundError as e:
+            print(e)
+            return []
+        except ValueError as e:
+            print(e)
+            raise
+            return []
+
+        card_rst = CARD_TEMPLATE.format(
+            header=header, image=image, link=link, card_description=card_description, tags=tags
+        )
+        card_list = StringList(card_rst.split("\n"))
+        card = nodes.paragraph()
+        self.state.nested_parse(card_list, self.content_offset, card)
+        return [card]
+
+
+CARD_TEMPLATE = """
+.. raw:: html
+
+    <div class="col-md-12 tutorials-card-container" data-tags={tags}>
+
+    <div class="card tutorials-card" link={link}>
+
+    <div class="card-body">
+
+    <div class="card-title-container">
+        <h4>{header}</h4>
+    </div>
+
+    <p class="card-summary">{card_description}</p>
+
+    <p class="tags">{tags}</p>
+
+    <div class="tutorials-image">{image}</div>
+
+    </div>
+
+    </div>
+
+    </div>
+"""
+
+
 class CustomCalloutItemDirective(Directive):
     option_spec = {
         "header": directives.unchanged,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

I misread our grep results in https://github.com/Qiskit/qiskit-metapackage/pull/1731. We do use `customcardelement`:

```
docs/tutorials.rst
20:.. customcarditem::

docs/getting_started.rst
86:       .. customcarditem::
92:       .. customcarditem::
```

CI did not catch this because the metapackage does not error on warnings. 

My bad! (The other removals were legitimate, though.)

I will move this directive to qiskit_sphinx_theme in https://github.com/Qiskit/qiskit_sphinx_theme/issues/323.
