### PR TITLE
Fix URLs used in stable docs deploys

### DIFF
--- a/docs/versionutils.py
+++ b/docs/versionutils.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def setup(app):
+    app.connect("config-inited", _extend_html_context)
     app.add_directive("version-history", _VersionHistory)
 
 

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -21,7 +21,7 @@ sudo apt-get install -y ./rclone.deb
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
 # Build the documentation.
-tox -edocs -- -D content_prefix=documentation -j auto
+tox -edocs -- -j auto
 
 echo "show current dir: "
 pwd

--- a/tools/deploy_documentation_tag.sh
+++ b/tools/deploy_documentation_tag.sh
@@ -33,7 +33,7 @@ STABLE_VERSION="${VERSION[0]}.${VERSION[1]}"
 echo "Building for stable version $STABLE_VERSION"
 
 # Build the documentation.
-tox -edocs -- -D content_prefix=documentation/stable/"$STABLE_VERSION" -j auto
+tox -edocs -- -D docs_url_prefix=documentation/stable/"$STABLE_VERSION" -j auto
 
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

I missed this in https://github.com/Qiskit/qiskit-metapackage/pull/1740. We renamed the option from `content_prefix` to `docs_url_prefix`.