### PR TITLE
Rewrite Maintainer's Guide to use Docs Guide & mention metapackage migration

### DIFF
--- a/docs/maintainers_guide.rst
+++ b/docs/maintainers_guide.rst
@@ -203,121 +203,24 @@ Documentation Structure
 The way documentation is structured in Qiskit is to push as much of the actual
 documentation into the docstrings as possible. This makes it easier for
 additions and corrections to be made during development, because the majority
-of the documentation lives near the code being changed. There are three levels in
-the normal documentation structure in Terra:
+of the documentation lives near the code being changed.
 
-The ``.rst`` files in the ``docs/apidocs``
-   These files are used to tell Sphinx which modules to include in the rendered
-   documentation. This contains two pieces of information:
-   an `internal reference <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#reference-names>`__
-   or `cross reference <https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#ref-role>`__
-   to the module, which can be used for internal links
-   inside the documentation, and an `automodule directive <http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`__
-   used to parse the
-   module docstrings from a specified import path. For example, the ``dagcircuit.rst``
-   file contains::
+Refer to https://qiskit.github.io/qiskit_sphinx_theme/apidocs/index.html for how to create and
+write effective API documentation, such as setting up the RST files and docstrings.
 
-      .. _qiskit-dagcircuit:
+qiskit-metapackage repository
+-----------------------------
 
+Historically, Qiskit Ecosystem projects were hosted at https://qiskit.org/documentation/.
+Those projects now live under https://qiskit.org/ecosystem, and qiskit.org/documentation is only for
+core Qiskit (aka Terra).
 
-      .. automodule:: qiskit.dagcircuit
-         :no-members:
-         :no-inherited-members:
-         :no-special-members:
-
-   The only ``.rst`` file outside of this is ``qiskit.rst``, which contains the table of
-   contents. If you're adding a new ``.rst`` file for a new module's documentation, make
-   sure to add it to the `toctree <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#table-of-contents>`__
-   in that file.
-
-The module-level docstring
-   This docstring is at the module
-   level for the module specified in the ``automodule`` directive in the rst file.
-   If the module specified is a directory/namespace, the docstring should be
-   specified in the ``__init__.py`` file for that directory. This module-level
-   docstring contains more details about the module being documented.
-   The normal structure to this docstring is to outline all the classes and
-   functions of the public API that are contained in that module. This is typically
-   done using the `autosummary directive <https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>`__
-   (or `autodoc directives <http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`__
-   directly if the module is simple, such as in the case of ``qiskit.execute``). The
-   autosummary directive is used to autodoc a list of different Python elements
-   (classes, functions, etc.) directly without having to manually call out the
-   autodoc directives for each one. The module-level docstring is where to
-   provide a high-level overview of what functionality the module provides.
-   This is normally done by grouping the different
-   components of the public API together into multiple subsections.
-
-   For example, as in the previous dagcircuit module example, the
-   contents of the module docstring for ``qiskit/dagcircuit/__init__.py`` would
-   be::
-
-      """
-      =======================================
-      DAG Circuits (:mod:`qiskit.dagcircuit`)
-      =======================================
-
-      .. currentmodule:: qiskit.dagcircuit
-
-      DAG Circuits
-      ============
-
-      .. autosummary::
-         :toctree: ../stubs/
-
-         DAGCircuit
-         DAGNode
-
-      Exceptions
-      ==========
-
-      .. autosummary::
-         :toctree: ../stubs/
-
-         DAGCircuitError
-      """
-
-   .. note::
-
-      This is just an example and the actual module docstring for the dagcircuit
-      module might diverge from this.
-
-The actual docstring for the elements listed in the module docstring
-   You should strive to document thoroughly all the public interfaces
-   exposed using examples when necessary. For docstrings, `Google Python Style
-   Docstrings <https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings>`__
-   are used. This is parsed using the `napoleon
-   sphinx extension <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`__.
-   The `napoleon documentation <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`__
-   contains a good example of how docstrings should be formatted.
-
-   .. note::
-      You can use any Sphinx directive or rst formatting in a docstring as it
-      makes sense. For example, one common extension used is the ``jupyter-execute``
-      directive, which is used to execute a code block in Jupyter and display both
-      the code and output. This is particularly useful for visualizations.
-
-
-
-Documentation Integration
--------------------------
-
-The hosted documentation at https://qiskit.org/documentation/ covers the entire
-Qiskit project; Terra is just one component of that. As such, the documentation
-builds for the hosted version are built by the Qiskit meta-package repository
-https://github.com/Qiskit/qiskit. When commits are merged to that repo, the
-output of Sphinx builds are uploaded to the qiskit.org website. Those Sphinx
-builds are configured to pull in the documentation from the version of the
-Qiskit elements installed by the meta-package at that point. For example, if
-the meta-package version is currently 0.13.0, then that will copy the
-documentation from Terra's 0.10.0 release. When the meta-package's requirements
-are bumped, then it will start pulling documentation from the new version. This
+While we finish this migration, documentation for Qiskit is still built in
+https://github.com/Qiskit/qiskit-metapackage. The metapackage will Git clone Terra to pull in its
+API documentation, using whatever version of Terra is pinned in the ``setup.py``. This
 means that fixes for incorrect API documentation will need to be
 included in a new release. Documentation fixes are valid backports for a stable
 patch release per the stable branch policy (see :ref:`stable_branch_policy`).
 
-During the build process, the contents of each element's ``docs/apidocs/``
-are recursively copied into a shared copy of ``doc/apidocs/`` in the meta-package
-repository along with all the other elements. This means that what is in the root of
-docs/apidocs on each element at a release will end up on the root of
-https://qiskit.org/documentation/apidoc/.
+This setup is temporary and we are migrating the metapackage documentation infrastructure to live
+in Terra.

--- a/docs/maintainers_guide.rst
+++ b/docs/maintainers_guide.rst
@@ -212,8 +212,8 @@ qiskit-metapackage repository
 -----------------------------
 
 Historically, Qiskit Ecosystem projects were hosted at https://qiskit.org/documentation/.
-Those projects now live under https://qiskit.org/ecosystem, and qiskit.org/documentation is only for
-core Qiskit (aka Terra).
+Those projects now live under https://qiskit.org/ecosystem and https://qiskit.org/documentation
+is only for core Qiskit (aka Terra).
 
 While we finish this migration, documentation for Qiskit is still built in
 https://github.com/Qiskit/qiskit-metapackage. The metapackage will Git clone Terra to pull in its
@@ -223,4 +223,4 @@ included in a new release. Documentation fixes are valid backports for a stable
 patch release per the stable branch policy (see :ref:`stable_branch_policy`).
 
 This setup is temporary and we are migrating the metapackage documentation infrastructure to live
-in Terra.
+in Terra. See https://github.com/Qiskit/RFCs/issues/41 to track the migration.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Originally, I was trying to fix an issue from Sphinx that it was trying to evaluate the directives inside our code block of example docstring. 

```
WARNING: [autosummary] failed to import qiskit.dagcircuit.Exceptions.
Possible hints:
* ModuleNotFoundError: No module named 'qiskit.dagcircuit.Exceptions'
* ImportError: 
* AttributeError: module 'qiskit.dagcircuit' has no attribute 'Exceptions'
```

I could not figure out how to fix that.

Instead, I realized we should be pointing to https://qiskit.github.io/qiskit_sphinx_theme/apidocs/index.html. We are currently duplicating docs we already wrote specifically for this context.

--

Likewise, this refreshes the explanation of the metapackage repo.