### PR TITLE
Add back tweedledum for Grover tutorial

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,9 @@ pillow>=4.2.1
 seaborn>=0.9.0
 nbsphinx
 cvxpy
+# Tweedledum is still used by qiskit-tutorials: 07_grover_examples.ipynb. While we won't eagerly
+# error if Tweedledum is missing, the tutorial output will be empty.
+tweedledum>=1.0.0,<2.0.0; python_version < '3.11' and platform_system != "Darwin"
 networkx>=2.3
 qiskit-qasm3-import; python_version>'3.7'
 


### PR DESCRIPTION
https://qiskit.org/documentation/tutorials/algorithms/07_grover_examples.html is currently missing its output.

We set `QISKIT_DOCS_BUILD_TUTORIALS` in our docs publishing. So it should be sufficient to only update this repository to fix the problem.