### PR TITLE
Add an example about spam to the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,6 +56,7 @@ Examples of unacceptable behavior by participants, even when presented as
 - "Doxxing," Publishing screenshots or quotes, especially from identity slack
   channels, private chat, or public events, without all quoted users' explicit
   consent.
+- Engaging in spamming activities, such as repeatedly sending unsolicited messages, LLMs (Large Language Models) output, advertisements, or promotional content to community members without previous IBM authorization.
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 


### PR DESCRIPTION
The current CoC does not explicitly mention "spam" (it is implicit in "Focusing on what is best for the community").

This PR adds spam as an example on unacceptable behavior (mentioning LLMs outputs, such as ChatGPT). While automated messages are sometimes used, they need explicit authorization. 