### PR TITLE
Add intersphinx extension for linking to other orgs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,14 +84,6 @@ nbsphinx_prolog = """
 
 """
 
-intersphinx_mapping = {
-    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
-    "qiskit-ibm-runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
-    "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
-}
-
 panels_css_variables = {
     "tabs-color-label-active": "rgb(138, 63, 252)",
     "tabs-color-label-inactive": "rgb(221, 225, 230)",
@@ -143,6 +135,14 @@ extlinks = {
         "https://github.com/Qiskit/qiskit-ibmq-provider/pull/%s",
         "qiskit-ibmq-provider #%s",
     ),
+}
+
+intersphinx_mapping = {
+    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
+    "qiskit-ibm-runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
+    "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",
     "qiskit_sphinx_theme",
     "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
 ]
 
 nbsphinx_timeout = 300
@@ -82,6 +83,14 @@ nbsphinx_prolog = """
     __ https://github.com/Qiskit/qiskit-tutorials/blob/master/{{ docname }}
 
 """
+
+intersphinx_mapping = {
+    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
+    "qiskit-ibm-runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
+    "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+}
 
 panels_css_variables = {
     "tabs-color-label-active": "rgb(138, 63, 252)",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adding intersphinx extension to allow for linking to other orgs in docs


### Details and comments

I added links for `matplotlib.figure.Figure` return types to the visualization docs in https://github.com/Qiskit/qiskit-terra/pull/10389 , and @Eric-Arellano  requested in https://github.com/Qiskit/qiskit-terra/pull/10389#pullrequestreview-1518994619 to make that change here as well. 

It didn't appear that the intersphinx extension was being used in this repo (I didn't find it in `docs/conf.py`), so I added the extension and all the mappings from qiskit-terra. Let me know if that's not the correct approach to take here.


