### PR TITLE
Remove textbook tutorials

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -37,7 +37,7 @@ Quantum circuits
 .. nbgallery::
    :glob:
 
-   tutorials/circuits/*
+   tutorials/circuits/*.ipynb
 
 Advanced circuits
 =================
@@ -45,7 +45,7 @@ Advanced circuits
 .. nbgallery::
    :glob:
 
-   tutorials/circuits_advanced/*
+   tutorials/circuits_advanced/*.ipynb
 
 Classical simulators
 ====================
@@ -53,7 +53,7 @@ Classical simulators
 .. nbgallery::
    :glob:
 
-   tutorials/simulators/*
+   tutorials/simulators/*.ipynb
 
 Algorithms
 ==========
@@ -61,7 +61,7 @@ Algorithms
 .. nbgallery::
    :glob:
 
-   tutorials/algorithms/*
+   tutorials/algorithms/*.ipynb
 
 Operators
 =========
@@ -69,15 +69,7 @@ Operators
 .. nbgallery::
    :glob:
 
-   tutorials/operators/*
-
-Sample algorithms in Qiskit
-===========================
-
-.. nbgallery::
-   :glob:
-
-   tutorials/textbook/*
+   tutorials/operators/*.ipynb
 
 .. Hiding - Indices and tables
    :ref:`genindex`

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -37,7 +37,7 @@ Quantum circuits
 .. nbgallery::
    :glob:
 
-   tutorials/circuits/*.ipynb
+   tutorials/circuits/*
 
 Advanced circuits
 =================
@@ -45,7 +45,7 @@ Advanced circuits
 .. nbgallery::
    :glob:
 
-   tutorials/circuits_advanced/*.ipynb
+   tutorials/circuits_advanced/*
 
 Classical simulators
 ====================
@@ -53,7 +53,7 @@ Classical simulators
 .. nbgallery::
    :glob:
 
-   tutorials/simulators/*.ipynb
+   tutorials/simulators/*
 
 Algorithms
 ==========
@@ -61,7 +61,7 @@ Algorithms
 .. nbgallery::
    :glob:
 
-   tutorials/algorithms/*.ipynb
+   tutorials/algorithms/*
 
 Operators
 =========
@@ -69,7 +69,7 @@ Operators
 .. nbgallery::
    :glob:
 
-   tutorials/operators/*.ipynb
+   tutorials/operators/*
 
 .. Hiding - Indices and tables
    :ref:`genindex`


### PR DESCRIPTION
These were removed in https://github.com/Qiskit/qiskit-tutorials/pull/1479. 

Note that I messed up and should have removed them from this repo before deleting in qiskit-tutorials. CI will be broken right now for the metapackage due to this mistake. My bad :/