### PR TITLE
Fix Black 23.7.0 issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 100
 target-version = ["py37", "py38", "py39", "py310", "py311"]
-extend-exclude = ["test/benchmarks/", "docs/plot_directive/"]
+extend-exclude = "['test/benchmarks/', 'docs/plot_directive/']"
 
 [tool.isort]
 profile = "black"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,5 +20,5 @@ networkx>=2.3
 qiskit-qasm3-import; python_version>'3.7'
 
 # Dev tooling
-black~=23.3
+black==23.7.0
 isort~=5.11


### PR DESCRIPTION
`extend-exclude` should have been a string. We simply use the old behavior of Black, which was to call `repr()` on the list. 

This also properly pins Black's version. I didn't realize they're using cal-ver, so `~=` doesn't work properly.