### PR TITLE
Fix add_module_names usage in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,7 +119,7 @@ gettext_compact = False  # optional.
 pygments_style = "colorful"
 
 # Whether module names are included in crossrefs of functions, classes, etc.
-add_module_names = False
+add_module_names = True
 
 # A list of prefixes that are ignored for sorting the Python module index
 # (e.g., if this is set to ['foo.'], then foo.bar is shown under B, not F).
@@ -185,7 +185,6 @@ autodoc_typehints = "description"
 # Only add type hints from signature to description body if the parameter has documentation.  The
 # return type is always added to the description (if in the signature).
 autodoc_typehints_description_target = "documented_params"
-add_module_name = True
 
 # Plot directive configuration
 # ----------------------------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the the recently merged #1784 we tried to update the add_module_names flag to be true to correspond to some organizational changes made to the docs in the release. However, a typo in that PR resulted in not actually setting the flag correctly. It also neglected that it was already set in the configuration file above to False. This commit removes the duplicate typo entry and just updates the existing entry to be the new setting.

### Details and comments


